### PR TITLE
Add FundRolesV2

### DIFF
--- a/contracts/fund/FundRolesV2.sol
+++ b/contracts/fund/FundRolesV2.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.10 <0.8.0;
+
+import "../interfaces/ITrancheIndex.sol";
+
+abstract contract FundRolesV2 is ITrancheIndex {
+    event PrimaryMarketUpdateProposed(
+        address indexed newPrimaryMarket,
+        uint256 minTimestamp,
+        uint256 maxTimestamp
+    );
+    event PrimaryMarketUpdated(
+        address indexed previousPrimaryMarket,
+        address indexed newPrimaryMarket
+    );
+    event StrategyUpdateProposed(
+        address indexed newStrategy,
+        uint256 minTimestamp,
+        uint256 maxTimestamp
+    );
+    event StrategyUpdated(address indexed previousStrategy, address indexed newStrategy);
+
+    uint256 private constant ROLE_UPDATE_MIN_DELAY = 3 days;
+    uint256 private constant ROLE_UPDATE_MAX_DELAY = 15 days;
+
+    address internal immutable _tokenM;
+    address internal immutable _tokenA;
+    address internal immutable _tokenB;
+
+    address public primaryMarket;
+    address public proposedPrimaryMarket;
+    uint256 public proposedPrimaryMarketTimestamp;
+
+    address public strategy;
+    address public proposedStrategy;
+    uint256 public proposedStrategyTimestamp;
+
+    constructor(
+        address tokenM_,
+        address tokenA_,
+        address tokenB_,
+        address primaryMarket_,
+        address strategy_
+    ) public {
+        _tokenM = tokenM_;
+        _tokenA = tokenA_;
+        _tokenB = tokenB_;
+        primaryMarket = primaryMarket_;
+        strategy = strategy_;
+        emit PrimaryMarketUpdated(address(0), primaryMarket_);
+        emit StrategyUpdated(address(0), strategy_);
+    }
+
+    modifier onlyShare() {
+        require(
+            msg.sender == _tokenM || msg.sender == _tokenA || msg.sender == _tokenB,
+            "Only share"
+        );
+        _;
+    }
+
+    modifier onlyPrimaryMarket() {
+        require(msg.sender == primaryMarket, "Only primary market");
+        _;
+    }
+
+    function _proposePrimaryMarketUpdate(address newPrimaryMarket) internal {
+        require(newPrimaryMarket != primaryMarket);
+        proposedPrimaryMarket = newPrimaryMarket;
+        proposedPrimaryMarketTimestamp = block.timestamp;
+        emit PrimaryMarketUpdateProposed(
+            newPrimaryMarket,
+            block.timestamp + ROLE_UPDATE_MIN_DELAY,
+            block.timestamp + ROLE_UPDATE_MAX_DELAY
+        );
+    }
+
+    function _applyPrimaryMarketUpdate(address newPrimaryMarket) internal {
+        require(proposedPrimaryMarket == newPrimaryMarket, "Proposed address mismatch");
+        require(
+            block.timestamp >= proposedPrimaryMarketTimestamp + ROLE_UPDATE_MIN_DELAY &&
+                block.timestamp < proposedPrimaryMarketTimestamp + ROLE_UPDATE_MAX_DELAY,
+            "Not ready to update"
+        );
+        emit PrimaryMarketUpdated(primaryMarket, newPrimaryMarket);
+        primaryMarket = newPrimaryMarket;
+        proposedPrimaryMarket = address(0);
+        proposedPrimaryMarketTimestamp = 0;
+    }
+
+    modifier onlyStrategy() {
+        require(msg.sender == strategy, "Only strategy");
+        _;
+    }
+
+    function _proposeStrategyUpdate(address newStrategy) internal {
+        require(newStrategy != strategy);
+        proposedStrategy = newStrategy;
+        proposedStrategyTimestamp = block.timestamp;
+        emit StrategyUpdateProposed(
+            newStrategy,
+            block.timestamp + ROLE_UPDATE_MIN_DELAY,
+            block.timestamp + ROLE_UPDATE_MAX_DELAY
+        );
+    }
+
+    function _applyStrategyUpdate(address newStrategy) internal {
+        require(proposedStrategy == newStrategy, "Proposed address mismatch");
+        require(
+            block.timestamp >= proposedStrategyTimestamp + ROLE_UPDATE_MIN_DELAY &&
+                block.timestamp < proposedStrategyTimestamp + ROLE_UPDATE_MAX_DELAY,
+            "Not ready to update"
+        );
+        emit StrategyUpdated(strategy, newStrategy);
+        strategy = newStrategy;
+        proposedStrategy = address(0);
+        proposedStrategyTimestamp = 0;
+    }
+}

--- a/contracts/fund/PrimaryMarketV3.sol
+++ b/contracts/fund/PrimaryMarketV3.sol
@@ -245,6 +245,11 @@ contract PrimaryMarketV3 is IPrimaryMarketV3, ReentrancyGuard, ITrancheIndex, Ow
         inAB = outMBeforeFee.add(1) / 2;
     }
 
+    /// @notice Return whether the fund can change its primary market to another contract.
+    function canBeRemovedFromFund() external view override returns (bool) {
+        return redemptionQueueHead == redemptionQueueTail;
+    }
+
     /// @notice Create Token M using underlying tokens.
     /// @param recipient Address that will receive created Token M
     /// @param underlying Spent underlying amount

--- a/contracts/interfaces/IPrimaryMarketV3.sol
+++ b/contracts/interfaces/IPrimaryMarketV3.sol
@@ -25,6 +25,8 @@ interface IPrimaryMarketV3 {
 
     function getMergeForM(uint256 minOutM) external view returns (uint256 inAB);
 
+    function canBeRemovedFromFund() external view returns (bool);
+
     function create(
         address recipient,
         uint256 underlying,

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,5 +1,4 @@
-import { Assertion } from "chai";
-import { BigNumber, BigNumberish, Wallet } from "ethers";
+import { Wallet } from "ethers";
 import { ethers } from "hardhat";
 
 export const TRANCHE_M = 0;


### PR DESCRIPTION
* Move `strategy` to FundRolesV2.
* Pack FundV3 constructor params into a struct to avoid the "Stack too deep" error.
* The fund has only one primary market now.
* Changing primary market has an internal timelock like strategy.
* Changing primary market is executed by the owner instead in `serttle()`. To be compatible with the old daily creation/redemption design, a primary market decides whether it can be removed from the fund.