### PR TITLE
Rename functions in Fund

### DIFF
--- a/contracts/fund/FundV3.sol
+++ b/contracts/fund/FundV3.sol
@@ -630,7 +630,7 @@ contract FundV3 is IFundV3, Ownable, ReentrancyGuard, FundRolesV2, CoreUtility {
         return _totalSupplies[tranche];
     }
 
-    function mint(
+    function primaryMarketMint(
         uint256 tranche,
         address account,
         uint256 amount,
@@ -640,7 +640,7 @@ contract FundV3 is IFundV3, Ownable, ReentrancyGuard, FundRolesV2, CoreUtility {
         _mint(tranche, account, amount);
     }
 
-    function burn(
+    function primaryMarketBurn(
         uint256 tranche,
         address account,
         uint256 amount,

--- a/contracts/fund/FundV3.sol
+++ b/contracts/fund/FundV3.sol
@@ -650,7 +650,7 @@ contract FundV3 is IFundV3, Ownable, ReentrancyGuard, FundRolesV2, CoreUtility {
         _burn(tranche, account, amount);
     }
 
-    function transfer(
+    function shareTransfer(
         uint256 tranche,
         address sender,
         address recipient,
@@ -662,14 +662,14 @@ contract FundV3 is IFundV3, Ownable, ReentrancyGuard, FundRolesV2, CoreUtility {
         _transfer(tranche, sender, recipient, amount);
     }
 
-    function transferFrom(
+    function shareTransferFrom(
         uint256 tranche,
         address spender,
         address sender,
         address recipient,
         uint256 amount
     ) external override onlyShare returns (uint256 newAllowance) {
-        transfer(tranche, sender, recipient, amount);
+        shareTransfer(tranche, sender, recipient, amount);
 
         _refreshAllowance(sender, spender, _rebalanceSize);
         newAllowance = _allowances[sender][spender][tranche].sub(
@@ -679,7 +679,7 @@ contract FundV3 is IFundV3, Ownable, ReentrancyGuard, FundRolesV2, CoreUtility {
         _approve(tranche, sender, spender, newAllowance);
     }
 
-    function approve(
+    function shareApprove(
         uint256 tranche,
         address owner,
         address spender,
@@ -689,7 +689,7 @@ contract FundV3 is IFundV3, Ownable, ReentrancyGuard, FundRolesV2, CoreUtility {
         _approve(tranche, owner, spender, amount);
     }
 
-    function increaseAllowance(
+    function shareIncreaseAllowance(
         uint256 tranche,
         address sender,
         address spender,
@@ -700,7 +700,7 @@ contract FundV3 is IFundV3, Ownable, ReentrancyGuard, FundRolesV2, CoreUtility {
         _approve(tranche, sender, spender, newAllowance);
     }
 
-    function decreaseAllowance(
+    function shareDecreaseAllowance(
         uint256 tranche,
         address sender,
         address spender,

--- a/contracts/fund/FundV3.sol
+++ b/contracts/fund/FundV3.sol
@@ -521,7 +521,7 @@ contract FundV3 is IFundV3, Ownable, ReentrancyGuard, FundRolesV2, CoreUtility {
         _refreshAllowance(owner, spender, targetVersion);
     }
 
-    function shareBalanceOf(uint256 tranche, address account)
+    function trancheBalanceOf(uint256 tranche, address account)
         external
         view
         override
@@ -555,7 +555,7 @@ contract FundV3 is IFundV3, Ownable, ReentrancyGuard, FundRolesV2, CoreUtility {
 
     /// @notice Return all three share balances transformed to the latest rebalance version.
     /// @param account Owner of the shares
-    function allShareBalanceOf(address account)
+    function trancheAllBalanceOf(address account)
         external
         view
         override
@@ -577,11 +577,11 @@ contract FundV3 is IFundV3, Ownable, ReentrancyGuard, FundRolesV2, CoreUtility {
         return (amountM, amountA, amountB);
     }
 
-    function shareBalanceVersion(address account) external view override returns (uint256) {
+    function trancheBalanceVersion(address account) external view override returns (uint256) {
         return _balanceVersions[account];
     }
 
-    function shareAllowance(
+    function trancheAllowance(
         uint256 tranche,
         address owner,
         address spender
@@ -617,7 +617,7 @@ contract FundV3 is IFundV3, Ownable, ReentrancyGuard, FundRolesV2, CoreUtility {
         }
     }
 
-    function shareAllowanceVersion(address owner, address spender)
+    function trancheAllowanceVersion(address owner, address spender)
         external
         view
         override
@@ -626,7 +626,7 @@ contract FundV3 is IFundV3, Ownable, ReentrancyGuard, FundRolesV2, CoreUtility {
         return _allowanceVersions[owner][spender];
     }
 
-    function shareTotalSupply(uint256 tranche) external view override returns (uint256) {
+    function trancheTotalSupply(uint256 tranche) external view override returns (uint256) {
         return _totalSupplies[tranche];
     }
 

--- a/contracts/fund/PrimaryMarketV3.sol
+++ b/contracts/fund/PrimaryMarketV3.sol
@@ -326,7 +326,7 @@ contract PrimaryMarketV3 is IPrimaryMarketV3, ReentrancyGuard, ITrancheIndex, Ow
     ) private onlyActive returns (uint256 shares) {
         shares = getCreation(underlying);
         require(shares >= minShares && shares > 0, "Min shares created");
-        fund.mint(TRANCHE_M, recipient, shares, version);
+        fund.primaryMarketMint(TRANCHE_M, recipient, shares, version);
         emit Created(recipient, underlying, shares);
     }
 
@@ -336,7 +336,7 @@ contract PrimaryMarketV3 is IPrimaryMarketV3, ReentrancyGuard, ITrancheIndex, Ow
         uint256 minUnderlying,
         uint256 version
     ) private onlyActive returns (uint256 underlying) {
-        fund.burn(TRANCHE_M, msg.sender, shares, version);
+        fund.primaryMarketBurn(TRANCHE_M, msg.sender, shares, version);
         _popRedemptionQueue(0);
         uint256 fee;
         (underlying, fee) = getRedemption(shares);
@@ -365,7 +365,7 @@ contract PrimaryMarketV3 is IPrimaryMarketV3, ReentrancyGuard, ITrancheIndex, Ow
         uint256 minUnderlying,
         uint256 version
     ) external override onlyActive nonReentrant returns (uint256 underlying, uint256 index) {
-        fund.burn(TRANCHE_M, msg.sender, shares, version);
+        fund.primaryMarketBurn(TRANCHE_M, msg.sender, shares, version);
         uint256 fee;
         (underlying, fee) = getRedemption(shares);
         require(underlying >= minUnderlying && underlying > 0, "Min underlying redeemed");
@@ -482,9 +482,9 @@ contract PrimaryMarketV3 is IPrimaryMarketV3, ReentrancyGuard, ITrancheIndex, Ow
         uint256 version
     ) external override onlyActive returns (uint256 outAB) {
         outAB = getSplit(inM);
-        fund.burn(TRANCHE_M, msg.sender, inM, version);
-        fund.mint(TRANCHE_A, recipient, outAB, version);
-        fund.mint(TRANCHE_B, recipient, outAB, version);
+        fund.primaryMarketBurn(TRANCHE_M, msg.sender, inM, version);
+        fund.primaryMarketMint(TRANCHE_A, recipient, outAB, version);
+        fund.primaryMarketMint(TRANCHE_B, recipient, outAB, version);
         emit Split(recipient, inM, outAB, outAB);
     }
 
@@ -495,9 +495,9 @@ contract PrimaryMarketV3 is IPrimaryMarketV3, ReentrancyGuard, ITrancheIndex, Ow
     ) external override onlyActive returns (uint256 outM) {
         uint256 feeM;
         (outM, feeM) = getMerge(inAB);
-        fund.burn(TRANCHE_A, msg.sender, inAB, version);
-        fund.burn(TRANCHE_B, msg.sender, inAB, version);
-        fund.mint(TRANCHE_M, recipient, outM, version);
+        fund.primaryMarketBurn(TRANCHE_A, msg.sender, inAB, version);
+        fund.primaryMarketBurn(TRANCHE_B, msg.sender, inAB, version);
+        fund.primaryMarketMint(TRANCHE_M, recipient, outM, version);
         fund.primaryMarketAddDebt(0, _getRedemptionBeforeFee(feeM));
         emit Merged(recipient, outM, inAB, inAB);
     }

--- a/contracts/interfaces/IFundV3.sol
+++ b/contracts/interfaces/IFundV3.sol
@@ -42,11 +42,11 @@ interface IFundV3 {
 
     function endOfDay(uint256 timestamp) external pure returns (uint256);
 
-    function shareTotalSupply(uint256 tranche) external view returns (uint256);
+    function trancheTotalSupply(uint256 tranche) external view returns (uint256);
 
-    function shareBalanceOf(uint256 tranche, address account) external view returns (uint256);
+    function trancheBalanceOf(uint256 tranche, address account) external view returns (uint256);
 
-    function allShareBalanceOf(address account)
+    function trancheAllBalanceOf(address account)
         external
         view
         returns (
@@ -55,15 +55,18 @@ interface IFundV3 {
             uint256
         );
 
-    function shareBalanceVersion(address account) external view returns (uint256);
+    function trancheBalanceVersion(address account) external view returns (uint256);
 
-    function shareAllowance(
+    function trancheAllowance(
         uint256 tranche,
         address owner,
         address spender
     ) external view returns (uint256);
 
-    function shareAllowanceVersion(address owner, address spender) external view returns (uint256);
+    function trancheAllowanceVersion(address owner, address spender)
+        external
+        view
+        returns (uint256);
 
     function getRebalanceSize() external view returns (uint256);
 

--- a/contracts/interfaces/IFundV3.sol
+++ b/contracts/interfaces/IFundV3.sol
@@ -164,14 +164,14 @@ interface IFundV3 {
         uint256 version
     ) external;
 
-    function transfer(
+    function shareTransfer(
         uint256 tranche,
         address sender,
         address recipient,
         uint256 amount
     ) external;
 
-    function transferFrom(
+    function shareTransferFrom(
         uint256 tranche,
         address spender,
         address sender,
@@ -179,21 +179,21 @@ interface IFundV3 {
         uint256 amount
     ) external returns (uint256 newAllowance);
 
-    function increaseAllowance(
+    function shareIncreaseAllowance(
         uint256 tranche,
         address sender,
         address spender,
         uint256 addedValue
     ) external returns (uint256 newAllowance);
 
-    function decreaseAllowance(
+    function shareDecreaseAllowance(
         uint256 tranche,
         address sender,
         address spender,
         uint256 subtractedValue
     ) external returns (uint256 newAllowance);
 
-    function approve(
+    function shareApprove(
         uint256 tranche,
         address owner,
         address spender,

--- a/contracts/interfaces/IFundV3.sol
+++ b/contracts/interfaces/IFundV3.sol
@@ -147,14 +147,14 @@ interface IFundV3 {
         uint256 targetVersion
     ) external;
 
-    function mint(
+    function primaryMarketMint(
         uint256 tranche,
         address account,
         uint256 amount,
         uint256 version
     ) external;
 
-    function burn(
+    function primaryMarketBurn(
         uint256 tranche,
         address account,
         uint256 amount,

--- a/test/fundV3.ts
+++ b/test/fundV3.ts
@@ -508,27 +508,27 @@ describe("FundV3", function () {
             await ethers.provider.send("hardhat_stopImpersonatingAccount", [primaryMarket.address]);
         });
 
-        describe("mint()", function () {
+        describe("primaryMarketMint()", function () {
             it("Should revert if not called from PrimaryMarket", async function () {
-                await expect(fund.connect(user1).mint(TRANCHE_M, addr1, 1, 0)).to.be.revertedWith(
-                    "Only primary market"
-                );
+                await expect(
+                    fund.connect(user1).primaryMarketMint(TRANCHE_M, addr1, 1, 0)
+                ).to.be.revertedWith("Only primary market");
             });
 
             it("Should revert if version mismatch", async function () {
-                await expect(fund.mint(TRANCHE_M, addr1, 1, 1)).to.be.revertedWith(
+                await expect(fund.primaryMarketMint(TRANCHE_M, addr1, 1, 1)).to.be.revertedWith(
                     "Only current version"
                 );
             });
 
             it("Should update balance and total supply", async function () {
-                await fund.mint(TRANCHE_M, addr1, 123, 0);
+                await fund.primaryMarketMint(TRANCHE_M, addr1, 123, 0);
                 expect(await fund.shareBalanceOf(TRANCHE_M, addr1)).to.equal(123);
-                await fund.mint(TRANCHE_M, addr1, 456, 0);
+                await fund.primaryMarketMint(TRANCHE_M, addr1, 456, 0);
                 expect(await fund.shareBalanceOf(TRANCHE_M, addr1)).to.equal(579);
-                await fund.mint(TRANCHE_M, addr2, 1000, 0);
-                await fund.mint(TRANCHE_A, addr2, 10, 0);
-                await fund.mint(TRANCHE_B, addr2, 100, 0);
+                await fund.primaryMarketMint(TRANCHE_M, addr2, 1000, 0);
+                await fund.primaryMarketMint(TRANCHE_A, addr2, 10, 0);
+                await fund.primaryMarketMint(TRANCHE_B, addr2, 100, 0);
                 expect(await fund.shareBalanceOf(TRANCHE_M, addr2)).to.equal(1000);
                 expect(await fund.shareBalanceOf(TRANCHE_A, addr2)).to.equal(10);
                 expect(await fund.shareBalanceOf(TRANCHE_B, addr2)).to.equal(100);
@@ -539,44 +539,44 @@ describe("FundV3", function () {
 
             it("Should revert on minting to the zero address", async function () {
                 await expect(
-                    fund.mint(TRANCHE_M, ethers.constants.AddressZero, 100, 0)
+                    fund.primaryMarketMint(TRANCHE_M, ethers.constants.AddressZero, 100, 0)
                 ).to.be.revertedWith("ERC20: mint to the zero address");
             });
 
             it("Should revert on overflow", async function () {
                 const HALF_MAX = BigNumber.from("2").pow(255);
-                await fund.mint(TRANCHE_M, addr1, HALF_MAX, 0);
-                await expect(fund.mint(TRANCHE_M, addr1, HALF_MAX, 0)).to.be.reverted;
-                await expect(fund.mint(TRANCHE_M, addr2, HALF_MAX, 0)).to.be.reverted;
+                await fund.primaryMarketMint(TRANCHE_M, addr1, HALF_MAX, 0);
+                await expect(fund.primaryMarketMint(TRANCHE_M, addr1, HALF_MAX, 0)).to.be.reverted;
+                await expect(fund.primaryMarketMint(TRANCHE_M, addr2, HALF_MAX, 0)).to.be.reverted;
             });
         });
 
-        describe("burn()", function () {
+        describe("primaryMarketBurn()", function () {
             it("Should revert if not called from PrimaryMarket", async function () {
-                await expect(fund.connect(user1).burn(TRANCHE_M, addr1, 1, 0)).to.be.revertedWith(
-                    "Only primary market"
-                );
+                await expect(
+                    fund.connect(user1).primaryMarketBurn(TRANCHE_M, addr1, 1, 0)
+                ).to.be.revertedWith("Only primary market");
             });
 
             it("Should revert if version mismatch", async function () {
-                await expect(fund.burn(TRANCHE_M, addr1, 1, 1)).to.be.revertedWith(
+                await expect(fund.primaryMarketBurn(TRANCHE_M, addr1, 1, 1)).to.be.revertedWith(
                     "Only current version"
                 );
             });
 
             it("Should update balance and total supply", async function () {
-                await fund.mint(TRANCHE_M, addr1, 10000, 0);
-                await fund.mint(TRANCHE_M, addr2, 10000, 0);
-                await fund.mint(TRANCHE_A, addr2, 10000, 0);
-                await fund.mint(TRANCHE_B, addr2, 10000, 0);
+                await fund.primaryMarketMint(TRANCHE_M, addr1, 10000, 0);
+                await fund.primaryMarketMint(TRANCHE_M, addr2, 10000, 0);
+                await fund.primaryMarketMint(TRANCHE_A, addr2, 10000, 0);
+                await fund.primaryMarketMint(TRANCHE_B, addr2, 10000, 0);
 
-                await fund.burn(TRANCHE_M, addr1, 1000, 0);
+                await fund.primaryMarketBurn(TRANCHE_M, addr1, 1000, 0);
                 expect(await fund.shareBalanceOf(TRANCHE_M, addr1)).to.equal(9000);
-                await fund.burn(TRANCHE_M, addr1, 2000, 0);
+                await fund.primaryMarketBurn(TRANCHE_M, addr1, 2000, 0);
                 expect(await fund.shareBalanceOf(TRANCHE_M, addr1)).to.equal(7000);
-                await fund.burn(TRANCHE_M, addr2, 100, 0);
-                await fund.burn(TRANCHE_A, addr2, 10, 0);
-                await fund.burn(TRANCHE_B, addr2, 1, 0);
+                await fund.primaryMarketBurn(TRANCHE_M, addr2, 100, 0);
+                await fund.primaryMarketBurn(TRANCHE_A, addr2, 10, 0);
+                await fund.primaryMarketBurn(TRANCHE_B, addr2, 1, 0);
                 expect(await fund.shareBalanceOf(TRANCHE_M, addr2)).to.equal(9900);
                 expect(await fund.shareBalanceOf(TRANCHE_A, addr2)).to.equal(9990);
                 expect(await fund.shareBalanceOf(TRANCHE_B, addr2)).to.equal(9999);
@@ -587,14 +587,14 @@ describe("FundV3", function () {
 
             it("Should revert on burning from the zero address", async function () {
                 await expect(
-                    fund.burn(TRANCHE_M, ethers.constants.AddressZero, 100, 0)
+                    fund.primaryMarketBurn(TRANCHE_M, ethers.constants.AddressZero, 100, 0)
                 ).to.be.revertedWith("ERC20: burn from the zero address");
             });
 
             it("Should revert if balance is not enough", async function () {
-                await expect(fund.burn(TRANCHE_M, addr1, 1, 0)).to.be.reverted;
-                await fund.mint(TRANCHE_M, addr1, 100, 0);
-                await expect(fund.burn(TRANCHE_M, addr1, 101, 0)).to.be.reverted;
+                await expect(fund.primaryMarketBurn(TRANCHE_M, addr1, 1, 0)).to.be.reverted;
+                await fund.primaryMarketMint(TRANCHE_M, addr1, 100, 0);
+                await expect(fund.primaryMarketBurn(TRANCHE_M, addr1, 101, 0)).to.be.reverted;
             });
         });
 
@@ -623,7 +623,7 @@ describe("FundV3", function () {
 
             it("Should update balance and keep total supply", async function () {
                 for (const { fundFromShare, tranche } of fundFromShares) {
-                    await fund.mint(tranche, addr2, 10000, 0);
+                    await fund.primaryMarketMint(tranche, addr2, 10000, 0);
                     await fundFromShare.transfer(tranche, addr2, addr1, 10000);
                     expect(await fund.shareBalanceOf(TRANCHE_M, addr1)).to.equal(10000);
                     expect(await fund.shareBalanceOf(TRANCHE_M, addr2)).to.equal(0);
@@ -1180,7 +1180,14 @@ describe("FundV3", function () {
             await advanceOneDayAndSettle();
 
             const day = (await fund.currentDay()).toNumber();
-            await primaryMarket.call(fund, "mint", TRANCHE_M, addr1, parseEther("1000"), 0);
+            await primaryMarket.call(
+                fund,
+                "primaryMarketMint",
+                TRANCHE_M,
+                addr1,
+                parseEther("1000"),
+                0
+            );
             await btc.mint(fund.address, parseBtc("1"));
             await advanceOneDayAndSettle();
 
@@ -1236,7 +1243,14 @@ describe("FundV3", function () {
         });
 
         it("Should not trigger at exactly upper rebalance threshold", async function () {
-            await primaryMarket.call(fund, "mint", TRANCHE_M, addr1, parseEther("1000"), 0);
+            await primaryMarket.call(
+                fund,
+                "primaryMarketMint",
+                TRANCHE_M,
+                addr1,
+                parseEther("1000"),
+                0
+            );
             await btc.mint(fund.address, parseBtc("1.5"));
             await advanceOneDayAndSettle();
             expect(await fund.getRebalanceSize()).to.equal(0);
@@ -1245,7 +1259,14 @@ describe("FundV3", function () {
         });
 
         it("Should not trigger at exactly lower rebalance threshold", async function () {
-            await primaryMarket.call(fund, "mint", TRANCHE_M, addr1, parseEther("1000"), 0);
+            await primaryMarket.call(
+                fund,
+                "primaryMarketMint",
+                TRANCHE_M,
+                addr1,
+                parseEther("1000"),
+                0
+            );
             await btc.mint(fund.address, parseBtc("0.75"));
             await advanceOneDayAndSettle();
             expect(await fund.getRebalanceSize()).to.equal(0);
@@ -1256,7 +1277,14 @@ describe("FundV3", function () {
         it("Should not trigger at exactly fixed rebalance threshold", async function () {
             // Set daily interest rate to 10%
             await aprOracle.mock.capture.returns(parseEther("0.1"));
-            await primaryMarket.call(fund, "mint", TRANCHE_M, addr1, parseEther("1000"), 0);
+            await primaryMarket.call(
+                fund,
+                "primaryMarketMint",
+                TRANCHE_M,
+                addr1,
+                parseEther("1000"),
+                0
+            );
             await btc.mint(fund.address, parseBtc("1"));
             await advanceOneDayAndSettle();
 
@@ -1290,12 +1318,12 @@ describe("FundV3", function () {
             await f.fund.settle();
             const addr1 = f.wallets.user1.address;
             const addr2 = f.wallets.user2.address;
-            await f.primaryMarket.call(f.fund, "mint", TRANCHE_M, addr1, INIT_P_1, 0);
-            await f.primaryMarket.call(f.fund, "mint", TRANCHE_A, addr1, INIT_A_1, 0);
-            await f.primaryMarket.call(f.fund, "mint", TRANCHE_B, addr1, INIT_B_1, 0);
-            await f.primaryMarket.call(f.fund, "mint", TRANCHE_M, addr2, INIT_P_2, 0);
-            await f.primaryMarket.call(f.fund, "mint", TRANCHE_A, addr2, INIT_A_2, 0);
-            await f.primaryMarket.call(f.fund, "mint", TRANCHE_B, addr2, INIT_B_2, 0);
+            await f.primaryMarket.call(f.fund, "primaryMarketMint", TRANCHE_M, addr1, INIT_P_1, 0);
+            await f.primaryMarket.call(f.fund, "primaryMarketMint", TRANCHE_A, addr1, INIT_A_1, 0);
+            await f.primaryMarket.call(f.fund, "primaryMarketMint", TRANCHE_B, addr1, INIT_B_1, 0);
+            await f.primaryMarket.call(f.fund, "primaryMarketMint", TRANCHE_M, addr2, INIT_P_2, 0);
+            await f.primaryMarket.call(f.fund, "primaryMarketMint", TRANCHE_A, addr2, INIT_A_2, 0);
+            await f.primaryMarket.call(f.fund, "primaryMarketMint", TRANCHE_B, addr2, INIT_B_2, 0);
             await f.btc.mint(f.fund.address, INIT_BTC);
             await advanceBlockAtTime(f.startDay + DAY);
             await f.fund.settle();
@@ -1529,20 +1557,20 @@ describe("FundV3", function () {
                 expect(await fund.shareBalanceOf(TRANCHE_B, addr2)).to.equal(oldB2);
             });
 
-            it("mint()", async function () {
+            it("primaryMarketMint()", async function () {
                 await preDefinedRebalance070();
                 await preDefinedRebalance200();
                 const oldA = await fund.shareBalanceOf(TRANCHE_A, addr1);
-                await primaryMarket.call(fund, "mint", TRANCHE_M, addr1, 1, 2);
+                await primaryMarket.call(fund, "primaryMarketMint", TRANCHE_M, addr1, 1, 2);
                 expect(await fund.shareBalanceVersion(addr1)).to.equal(2);
                 expect(await fund.shareBalanceOf(TRANCHE_A, addr1)).to.equal(oldA);
             });
 
-            it("burn()", async function () {
+            it("primaryMarketBurn()", async function () {
                 await preDefinedRebalance070();
                 await preDefinedRebalance200();
                 const oldB = await fund.shareBalanceOf(TRANCHE_B, addr2);
-                await primaryMarket.call(fund, "burn", TRANCHE_A, addr2, 1, 2);
+                await primaryMarket.call(fund, "primaryMarketBurn", TRANCHE_A, addr2, 1, 2);
                 expect(await fund.shareBalanceVersion(addr2)).to.equal(2);
                 expect(await fund.shareBalanceOf(TRANCHE_B, addr2)).to.equal(oldB);
             });

--- a/test/fundV3.ts
+++ b/test/fundV3.ts
@@ -180,7 +180,7 @@ describe("FundV3", function () {
 
             expect(await fund.isFundActive(startDay + HOUR * 12 - 1)).to.equal(false);
             await expect(
-                fund.connect(shareM).transfer(TRANCHE_M, addr1, addr2, 0)
+                fund.connect(shareM).shareTransfer(TRANCHE_M, addr1, addr2, 0)
             ).to.be.revertedWith("Transfer is inactive");
         });
 
@@ -600,7 +600,7 @@ describe("FundV3", function () {
 
         describe("transfer()", function () {
             it("Should revert if not called from Share", async function () {
-                await expect(fund.transfer(TRANCHE_M, addr1, addr2, 1)).to.be.revertedWith(
+                await expect(fund.shareTransfer(TRANCHE_M, addr1, addr2, 1)).to.be.revertedWith(
                     "Only share"
                 );
             });
@@ -608,7 +608,7 @@ describe("FundV3", function () {
             it("Should reject transfer from the zero address", async function () {
                 for (const { fundFromShare, tranche } of fundFromShares) {
                     await expect(
-                        fundFromShare.transfer(tranche, ethers.constants.AddressZero, addr1, 1)
+                        fundFromShare.shareTransfer(tranche, ethers.constants.AddressZero, addr1, 1)
                     ).to.be.revertedWith("ERC20: transfer from the zero address");
                 }
             });
@@ -616,7 +616,7 @@ describe("FundV3", function () {
             it("Should reject transfer to the zero address", async function () {
                 for (const { fundFromShare, tranche } of fundFromShares) {
                     await expect(
-                        fundFromShare.transfer(tranche, addr1, ethers.constants.AddressZero, 1)
+                        fundFromShare.shareTransfer(tranche, addr1, ethers.constants.AddressZero, 1)
                     ).to.be.revertedWith("ERC20: transfer to the zero address");
                 }
             });
@@ -624,7 +624,7 @@ describe("FundV3", function () {
             it("Should update balance and keep total supply", async function () {
                 for (const { fundFromShare, tranche } of fundFromShares) {
                     await fund.primaryMarketMint(tranche, addr2, 10000, 0);
-                    await fundFromShare.transfer(tranche, addr2, addr1, 10000);
+                    await fundFromShare.shareTransfer(tranche, addr2, addr1, 10000);
                     expect(await fund.trancheBalanceOf(TRANCHE_M, addr1)).to.equal(10000);
                     expect(await fund.trancheBalanceOf(TRANCHE_M, addr2)).to.equal(0);
                     expect(await fund.trancheTotalSupply(TRANCHE_M)).to.equal(10000);
@@ -634,7 +634,7 @@ describe("FundV3", function () {
             it("Should revert if balance is not enough", async function () {
                 for (const { fundFromShare, tranche } of fundFromShares) {
                     await expect(
-                        fundFromShare.transfer(tranche, addr2, addr1, 10001)
+                        fundFromShare.shareTransfer(tranche, addr2, addr1, 10001)
                     ).to.be.revertedWith("ERC20: transfer amount exceeds balance");
                 }
             });
@@ -642,7 +642,7 @@ describe("FundV3", function () {
 
         describe("approve()", function () {
             it("Should revert if not called from Share", async function () {
-                await expect(fund.approve(TRANCHE_M, addr1, addr2, 1)).to.be.revertedWith(
+                await expect(fund.shareApprove(TRANCHE_M, addr1, addr2, 1)).to.be.revertedWith(
                     "Only share"
                 );
             });
@@ -650,7 +650,7 @@ describe("FundV3", function () {
             it("Should reject approval from the zero address", async function () {
                 for (const { fundFromShare, tranche } of fundFromShares) {
                     await expect(
-                        fundFromShare.approve(tranche, ethers.constants.AddressZero, addr1, 1)
+                        fundFromShare.shareApprove(tranche, ethers.constants.AddressZero, addr1, 1)
                     ).to.be.revertedWith("ERC20: approve from the zero address");
                 }
             });
@@ -658,7 +658,7 @@ describe("FundV3", function () {
             it("Should reject approval to the zero address", async function () {
                 for (const { fundFromShare, tranche } of fundFromShares) {
                     await expect(
-                        fundFromShare.approve(tranche, addr1, ethers.constants.AddressZero, 1)
+                        fundFromShare.shareApprove(tranche, addr1, ethers.constants.AddressZero, 1)
                     ).to.be.revertedWith("ERC20: approve to the zero address");
                 }
             });
@@ -666,9 +666,9 @@ describe("FundV3", function () {
             it("Should update allowance", async function () {
                 for (const { fundFromShare, tranche } of fundFromShares) {
                     expect(await fund.trancheAllowance(tranche, addr1, addr2)).to.equal(0);
-                    await fundFromShare.approve(tranche, addr1, addr2, 100);
+                    await fundFromShare.shareApprove(tranche, addr1, addr2, 100);
                     expect(await fund.trancheAllowance(tranche, addr1, addr2)).to.equal(100);
-                    await fundFromShare.approve(tranche, addr1, addr2, 10);
+                    await fundFromShare.shareApprove(tranche, addr1, addr2, 10);
                     expect(await fund.trancheAllowance(tranche, addr1, addr2)).to.equal(10);
                 }
             });
@@ -1550,7 +1550,7 @@ describe("FundV3", function () {
                 const oldA1 = await fund.trancheBalanceOf(TRANCHE_A, addr1);
                 const oldB2 = await fund.trancheBalanceOf(TRANCHE_B, addr2);
                 await advanceOneDayAndSettle();
-                await fund.connect(shareM).transfer(TRANCHE_M, addr1, addr2, 1);
+                await fund.connect(shareM).shareTransfer(TRANCHE_M, addr1, addr2, 1);
                 expect(await fund.trancheBalanceVersion(addr1)).to.equal(2);
                 expect(await fund.trancheBalanceVersion(addr2)).to.equal(2);
                 expect(await fund.trancheBalanceOf(TRANCHE_A, addr1)).to.equal(oldA1);

--- a/test/fundV3.ts
+++ b/test/fundV3.ts
@@ -523,18 +523,18 @@ describe("FundV3", function () {
 
             it("Should update balance and total supply", async function () {
                 await fund.primaryMarketMint(TRANCHE_M, addr1, 123, 0);
-                expect(await fund.shareBalanceOf(TRANCHE_M, addr1)).to.equal(123);
+                expect(await fund.trancheBalanceOf(TRANCHE_M, addr1)).to.equal(123);
                 await fund.primaryMarketMint(TRANCHE_M, addr1, 456, 0);
-                expect(await fund.shareBalanceOf(TRANCHE_M, addr1)).to.equal(579);
+                expect(await fund.trancheBalanceOf(TRANCHE_M, addr1)).to.equal(579);
                 await fund.primaryMarketMint(TRANCHE_M, addr2, 1000, 0);
                 await fund.primaryMarketMint(TRANCHE_A, addr2, 10, 0);
                 await fund.primaryMarketMint(TRANCHE_B, addr2, 100, 0);
-                expect(await fund.shareBalanceOf(TRANCHE_M, addr2)).to.equal(1000);
-                expect(await fund.shareBalanceOf(TRANCHE_A, addr2)).to.equal(10);
-                expect(await fund.shareBalanceOf(TRANCHE_B, addr2)).to.equal(100);
-                expect(await fund.shareTotalSupply(TRANCHE_M)).to.equal(1579);
-                expect(await fund.shareTotalSupply(TRANCHE_A)).to.equal(10);
-                expect(await fund.shareTotalSupply(TRANCHE_B)).to.equal(100);
+                expect(await fund.trancheBalanceOf(TRANCHE_M, addr2)).to.equal(1000);
+                expect(await fund.trancheBalanceOf(TRANCHE_A, addr2)).to.equal(10);
+                expect(await fund.trancheBalanceOf(TRANCHE_B, addr2)).to.equal(100);
+                expect(await fund.trancheTotalSupply(TRANCHE_M)).to.equal(1579);
+                expect(await fund.trancheTotalSupply(TRANCHE_A)).to.equal(10);
+                expect(await fund.trancheTotalSupply(TRANCHE_B)).to.equal(100);
             });
 
             it("Should revert on minting to the zero address", async function () {
@@ -571,18 +571,18 @@ describe("FundV3", function () {
                 await fund.primaryMarketMint(TRANCHE_B, addr2, 10000, 0);
 
                 await fund.primaryMarketBurn(TRANCHE_M, addr1, 1000, 0);
-                expect(await fund.shareBalanceOf(TRANCHE_M, addr1)).to.equal(9000);
+                expect(await fund.trancheBalanceOf(TRANCHE_M, addr1)).to.equal(9000);
                 await fund.primaryMarketBurn(TRANCHE_M, addr1, 2000, 0);
-                expect(await fund.shareBalanceOf(TRANCHE_M, addr1)).to.equal(7000);
+                expect(await fund.trancheBalanceOf(TRANCHE_M, addr1)).to.equal(7000);
                 await fund.primaryMarketBurn(TRANCHE_M, addr2, 100, 0);
                 await fund.primaryMarketBurn(TRANCHE_A, addr2, 10, 0);
                 await fund.primaryMarketBurn(TRANCHE_B, addr2, 1, 0);
-                expect(await fund.shareBalanceOf(TRANCHE_M, addr2)).to.equal(9900);
-                expect(await fund.shareBalanceOf(TRANCHE_A, addr2)).to.equal(9990);
-                expect(await fund.shareBalanceOf(TRANCHE_B, addr2)).to.equal(9999);
-                expect(await fund.shareTotalSupply(TRANCHE_M)).to.equal(16900);
-                expect(await fund.shareTotalSupply(TRANCHE_A)).to.equal(9990);
-                expect(await fund.shareTotalSupply(TRANCHE_B)).to.equal(9999);
+                expect(await fund.trancheBalanceOf(TRANCHE_M, addr2)).to.equal(9900);
+                expect(await fund.trancheBalanceOf(TRANCHE_A, addr2)).to.equal(9990);
+                expect(await fund.trancheBalanceOf(TRANCHE_B, addr2)).to.equal(9999);
+                expect(await fund.trancheTotalSupply(TRANCHE_M)).to.equal(16900);
+                expect(await fund.trancheTotalSupply(TRANCHE_A)).to.equal(9990);
+                expect(await fund.trancheTotalSupply(TRANCHE_B)).to.equal(9999);
             });
 
             it("Should revert on burning from the zero address", async function () {
@@ -625,9 +625,9 @@ describe("FundV3", function () {
                 for (const { fundFromShare, tranche } of fundFromShares) {
                     await fund.primaryMarketMint(tranche, addr2, 10000, 0);
                     await fundFromShare.transfer(tranche, addr2, addr1, 10000);
-                    expect(await fund.shareBalanceOf(TRANCHE_M, addr1)).to.equal(10000);
-                    expect(await fund.shareBalanceOf(TRANCHE_M, addr2)).to.equal(0);
-                    expect(await fund.shareTotalSupply(TRANCHE_M)).to.equal(10000);
+                    expect(await fund.trancheBalanceOf(TRANCHE_M, addr1)).to.equal(10000);
+                    expect(await fund.trancheBalanceOf(TRANCHE_M, addr2)).to.equal(0);
+                    expect(await fund.trancheTotalSupply(TRANCHE_M)).to.equal(10000);
                 }
             });
 
@@ -665,11 +665,11 @@ describe("FundV3", function () {
 
             it("Should update allowance", async function () {
                 for (const { fundFromShare, tranche } of fundFromShares) {
-                    expect(await fund.shareAllowance(tranche, addr1, addr2)).to.equal(0);
+                    expect(await fund.trancheAllowance(tranche, addr1, addr2)).to.equal(0);
                     await fundFromShare.approve(tranche, addr1, addr2, 100);
-                    expect(await fund.shareAllowance(tranche, addr1, addr2)).to.equal(100);
+                    expect(await fund.trancheAllowance(tranche, addr1, addr2)).to.equal(100);
                     await fundFromShare.approve(tranche, addr1, addr2, 10);
-                    expect(await fund.shareAllowance(tranche, addr1, addr2)).to.equal(10);
+                    expect(await fund.trancheAllowance(tranche, addr1, addr2)).to.equal(10);
                 }
             });
         });
@@ -753,7 +753,7 @@ describe("FundV3", function () {
             await btc.mint(primaryMarket.address, parseBtc("1"));
             await primaryMarketSettle.returns(parseEther("1010"), 0, parseBtc("1"), 0, 0);
             await fund.settle();
-            expect(await fund.shareBalanceOf(TRANCHE_M, primaryMarket.address)).to.equal(
+            expect(await fund.trancheBalanceOf(TRANCHE_M, primaryMarket.address)).to.equal(
                 parseEther("1010")
             );
         });
@@ -792,7 +792,7 @@ describe("FundV3", function () {
             expect(navs[TRANCHE_A]).to.equal(parseEther("1"));
             expect(navs[TRANCHE_B]).to.equal(parseEther("1"));
             // Shares in the primary market is rebalanced on read
-            expect(await fund.shareBalanceOf(TRANCHE_M, primaryMarket.address)).to.equal(
+            expect(await fund.trancheBalanceOf(TRANCHE_M, primaryMarket.address)).to.equal(
                 parseEther("1010")
             );
         });
@@ -887,13 +887,13 @@ describe("FundV3", function () {
                 parseBtc("0.4"),
                 0
             );
-            const oldM = await fund.shareBalanceOf(TRANCHE_M, primaryMarket.address);
+            const oldM = await fund.trancheBalanceOf(TRANCHE_M, primaryMarket.address);
             await expect(() => fund.settle()).to.changeTokenBalances(
                 btc,
                 [fund, primaryMarket],
                 [parseBtc("0.6").sub(protocolFee), parseBtc("-0.6")]
             );
-            expect(await fund.shareBalanceOf(TRANCHE_M, primaryMarket.address)).to.equal(
+            expect(await fund.trancheBalanceOf(TRANCHE_M, primaryMarket.address)).to.equal(
                 oldM.add(parseEther("600"))
             );
         });
@@ -908,14 +908,14 @@ describe("FundV3", function () {
                 parseBtc("4"),
                 0
             );
-            const oldM = await fund.shareBalanceOf(TRANCHE_M, primaryMarket.address);
+            const oldM = await fund.trancheBalanceOf(TRANCHE_M, primaryMarket.address);
             await expect(() => fund.settle()).to.changeTokenBalances(
                 btc,
                 [fund, primaryMarket],
                 [protocolFee.mul(-1), 0]
             );
             expect(await fund.redemptionDebts(primaryMarket.address)).to.equal(parseBtc("3"));
-            expect(await fund.shareBalanceOf(TRANCHE_M, primaryMarket.address)).to.equal(
+            expect(await fund.trancheBalanceOf(TRANCHE_M, primaryMarket.address)).to.equal(
                 oldM.sub(parseEther("3000"))
             );
         });
@@ -1388,15 +1388,15 @@ describe("FundV3", function () {
                 expect(rebalance.ratioB2M).to.equal(parseEther("1.3"));
                 expect(rebalance.ratioAB).to.equal(parseEther("1"));
                 expect(rebalance.timestamp).to.equal(settlementTimestamp);
-                expect(await fund.shareBalanceOf(TRANCHE_M, addr1)).to.equal(parseEther("690"));
-                expect(await fund.shareBalanceOf(TRANCHE_A, addr1)).to.equal(parseEther("100"));
-                expect(await fund.shareBalanceOf(TRANCHE_B, addr1)).to.equal(0);
-                expect(await fund.shareBalanceOf(TRANCHE_M, addr2)).to.equal(parseEther("410"));
-                expect(await fund.shareBalanceOf(TRANCHE_A, addr2)).to.equal(parseEther("200"));
-                expect(await fund.shareBalanceOf(TRANCHE_B, addr2)).to.equal(parseEther("300"));
-                expect(await fund.shareTotalSupply(TRANCHE_M)).to.equal(parseEther("1100"));
-                expect(await fund.shareTotalSupply(TRANCHE_A)).to.equal(parseEther("300"));
-                expect(await fund.shareTotalSupply(TRANCHE_B)).to.equal(parseEther("300"));
+                expect(await fund.trancheBalanceOf(TRANCHE_M, addr1)).to.equal(parseEther("690"));
+                expect(await fund.trancheBalanceOf(TRANCHE_A, addr1)).to.equal(parseEther("100"));
+                expect(await fund.trancheBalanceOf(TRANCHE_B, addr1)).to.equal(0);
+                expect(await fund.trancheBalanceOf(TRANCHE_M, addr2)).to.equal(parseEther("410"));
+                expect(await fund.trancheBalanceOf(TRANCHE_A, addr2)).to.equal(parseEther("200"));
+                expect(await fund.trancheBalanceOf(TRANCHE_B, addr2)).to.equal(parseEther("300"));
+                expect(await fund.trancheTotalSupply(TRANCHE_M)).to.equal(parseEther("1100"));
+                expect(await fund.trancheTotalSupply(TRANCHE_A)).to.equal(parseEther("300"));
+                expect(await fund.trancheTotalSupply(TRANCHE_B)).to.equal(parseEther("300"));
                 expect(await fund.getTotalShares()).to.equal(parseEther("1700"));
             });
 
@@ -1414,15 +1414,15 @@ describe("FundV3", function () {
                 expect(rebalance.ratioB2M).to.equal(0);
                 expect(rebalance.ratioAB).to.equal(parseEther("0.3"));
                 expect(rebalance.timestamp).to.equal(settlementTimestamp);
-                expect(await fund.shareBalanceOf(TRANCHE_M, addr1)).to.equal(parseEther("360"));
-                expect(await fund.shareBalanceOf(TRANCHE_A, addr1)).to.equal(parseEther("30"));
-                expect(await fund.shareBalanceOf(TRANCHE_B, addr1)).to.equal(0);
-                expect(await fund.shareBalanceOf(TRANCHE_M, addr2)).to.equal(parseEther("160"));
-                expect(await fund.shareBalanceOf(TRANCHE_A, addr2)).to.equal(parseEther("60"));
-                expect(await fund.shareBalanceOf(TRANCHE_B, addr2)).to.equal(parseEther("90"));
-                expect(await fund.shareTotalSupply(TRANCHE_M)).to.equal(parseEther("520"));
-                expect(await fund.shareTotalSupply(TRANCHE_A)).to.equal(parseEther("90"));
-                expect(await fund.shareTotalSupply(TRANCHE_B)).to.equal(parseEther("90"));
+                expect(await fund.trancheBalanceOf(TRANCHE_M, addr1)).to.equal(parseEther("360"));
+                expect(await fund.trancheBalanceOf(TRANCHE_A, addr1)).to.equal(parseEther("30"));
+                expect(await fund.trancheBalanceOf(TRANCHE_B, addr1)).to.equal(0);
+                expect(await fund.trancheBalanceOf(TRANCHE_M, addr2)).to.equal(parseEther("160"));
+                expect(await fund.trancheBalanceOf(TRANCHE_A, addr2)).to.equal(parseEther("60"));
+                expect(await fund.trancheBalanceOf(TRANCHE_B, addr2)).to.equal(parseEther("90"));
+                expect(await fund.trancheTotalSupply(TRANCHE_M)).to.equal(parseEther("520"));
+                expect(await fund.trancheTotalSupply(TRANCHE_A)).to.equal(parseEther("90"));
+                expect(await fund.trancheTotalSupply(TRANCHE_B)).to.equal(parseEther("90"));
                 expect(await fund.getTotalShares()).to.equal(parseEther("700"));
             });
 
@@ -1440,15 +1440,15 @@ describe("FundV3", function () {
                 expect(rebalance.ratioB2M).to.equal(0);
                 expect(rebalance.ratioAB).to.equal(0);
                 expect(rebalance.timestamp).to.equal(settlementTimestamp);
-                expect(await fund.shareBalanceOf(TRANCHE_M, addr1)).to.equal(parseEther("240"));
-                expect(await fund.shareBalanceOf(TRANCHE_A, addr1)).to.equal(0);
-                expect(await fund.shareBalanceOf(TRANCHE_B, addr1)).to.equal(0);
-                expect(await fund.shareBalanceOf(TRANCHE_M, addr2)).to.equal(parseEther("160"));
-                expect(await fund.shareBalanceOf(TRANCHE_A, addr2)).to.equal(0);
-                expect(await fund.shareBalanceOf(TRANCHE_B, addr2)).to.equal(0);
-                expect(await fund.shareTotalSupply(TRANCHE_M)).to.equal(parseEther("400"));
-                expect(await fund.shareTotalSupply(TRANCHE_A)).to.equal(0);
-                expect(await fund.shareTotalSupply(TRANCHE_B)).to.equal(0);
+                expect(await fund.trancheBalanceOf(TRANCHE_M, addr1)).to.equal(parseEther("240"));
+                expect(await fund.trancheBalanceOf(TRANCHE_A, addr1)).to.equal(0);
+                expect(await fund.trancheBalanceOf(TRANCHE_B, addr1)).to.equal(0);
+                expect(await fund.trancheBalanceOf(TRANCHE_M, addr2)).to.equal(parseEther("160"));
+                expect(await fund.trancheBalanceOf(TRANCHE_A, addr2)).to.equal(0);
+                expect(await fund.trancheBalanceOf(TRANCHE_B, addr2)).to.equal(0);
+                expect(await fund.trancheTotalSupply(TRANCHE_M)).to.equal(parseEther("400"));
+                expect(await fund.trancheTotalSupply(TRANCHE_A)).to.equal(0);
+                expect(await fund.trancheTotalSupply(TRANCHE_B)).to.equal(0);
                 expect(await fund.getTotalShares()).to.equal(parseEther("400"));
             });
         });
@@ -1540,39 +1540,39 @@ describe("FundV3", function () {
             it("No refresh when rebalance is triggered", async function () {
                 await preDefinedRebalance070();
                 await preDefinedRebalance200();
-                expect(await fund.shareBalanceVersion(addr1)).to.equal(0);
-                expect(await fund.shareBalanceVersion(addr2)).to.equal(0);
+                expect(await fund.trancheBalanceVersion(addr1)).to.equal(0);
+                expect(await fund.trancheBalanceVersion(addr2)).to.equal(0);
             });
 
             it("transfer()", async function () {
                 await preDefinedRebalance070();
                 await preDefinedRebalance200();
-                const oldA1 = await fund.shareBalanceOf(TRANCHE_A, addr1);
-                const oldB2 = await fund.shareBalanceOf(TRANCHE_B, addr2);
+                const oldA1 = await fund.trancheBalanceOf(TRANCHE_A, addr1);
+                const oldB2 = await fund.trancheBalanceOf(TRANCHE_B, addr2);
                 await advanceOneDayAndSettle();
                 await fund.connect(shareM).transfer(TRANCHE_M, addr1, addr2, 1);
-                expect(await fund.shareBalanceVersion(addr1)).to.equal(2);
-                expect(await fund.shareBalanceVersion(addr2)).to.equal(2);
-                expect(await fund.shareBalanceOf(TRANCHE_A, addr1)).to.equal(oldA1);
-                expect(await fund.shareBalanceOf(TRANCHE_B, addr2)).to.equal(oldB2);
+                expect(await fund.trancheBalanceVersion(addr1)).to.equal(2);
+                expect(await fund.trancheBalanceVersion(addr2)).to.equal(2);
+                expect(await fund.trancheBalanceOf(TRANCHE_A, addr1)).to.equal(oldA1);
+                expect(await fund.trancheBalanceOf(TRANCHE_B, addr2)).to.equal(oldB2);
             });
 
             it("primaryMarketMint()", async function () {
                 await preDefinedRebalance070();
                 await preDefinedRebalance200();
-                const oldA = await fund.shareBalanceOf(TRANCHE_A, addr1);
+                const oldA = await fund.trancheBalanceOf(TRANCHE_A, addr1);
                 await primaryMarket.call(fund, "primaryMarketMint", TRANCHE_M, addr1, 1, 2);
-                expect(await fund.shareBalanceVersion(addr1)).to.equal(2);
-                expect(await fund.shareBalanceOf(TRANCHE_A, addr1)).to.equal(oldA);
+                expect(await fund.trancheBalanceVersion(addr1)).to.equal(2);
+                expect(await fund.trancheBalanceOf(TRANCHE_A, addr1)).to.equal(oldA);
             });
 
             it("primaryMarketBurn()", async function () {
                 await preDefinedRebalance070();
                 await preDefinedRebalance200();
-                const oldB = await fund.shareBalanceOf(TRANCHE_B, addr2);
+                const oldB = await fund.trancheBalanceOf(TRANCHE_B, addr2);
                 await primaryMarket.call(fund, "primaryMarketBurn", TRANCHE_A, addr2, 1, 2);
-                expect(await fund.shareBalanceVersion(addr2)).to.equal(2);
-                expect(await fund.shareBalanceOf(TRANCHE_B, addr2)).to.equal(oldB);
+                expect(await fund.trancheBalanceVersion(addr2)).to.equal(2);
+                expect(await fund.trancheBalanceOf(TRANCHE_B, addr2)).to.equal(oldB);
             });
         });
 
@@ -1583,48 +1583,48 @@ describe("FundV3", function () {
                 await preDefinedRebalance170();
                 await preDefinedRebalance040();
                 await preDefinedRebalance070();
-                const oldM = await fund.shareBalanceOf(TRANCHE_M, addr1);
-                const oldA = await fund.shareBalanceOf(TRANCHE_A, addr1);
-                const oldB = await fund.shareBalanceOf(TRANCHE_B, addr1);
+                const oldM = await fund.trancheBalanceOf(TRANCHE_M, addr1);
+                const oldA = await fund.trancheBalanceOf(TRANCHE_A, addr1);
+                const oldB = await fund.trancheBalanceOf(TRANCHE_B, addr1);
                 await fund.refreshBalance(addr1, 2);
-                expect(await fund.shareBalanceVersion(addr1)).to.equal(2);
-                expect(await fund.shareBalanceOf(TRANCHE_M, addr1)).to.equal(oldM);
-                expect(await fund.shareBalanceOf(TRANCHE_A, addr1)).to.equal(oldA);
-                expect(await fund.shareBalanceOf(TRANCHE_B, addr1)).to.equal(oldB);
+                expect(await fund.trancheBalanceVersion(addr1)).to.equal(2);
+                expect(await fund.trancheBalanceOf(TRANCHE_M, addr1)).to.equal(oldM);
+                expect(await fund.trancheBalanceOf(TRANCHE_A, addr1)).to.equal(oldA);
+                expect(await fund.trancheBalanceOf(TRANCHE_B, addr1)).to.equal(oldB);
                 await fund.refreshBalance(addr1, 5);
-                expect(await fund.shareBalanceVersion(addr1)).to.equal(5);
-                expect(await fund.shareBalanceOf(TRANCHE_M, addr1)).to.equal(oldM);
-                expect(await fund.shareBalanceOf(TRANCHE_A, addr1)).to.equal(oldA);
-                expect(await fund.shareBalanceOf(TRANCHE_B, addr1)).to.equal(oldB);
+                expect(await fund.trancheBalanceVersion(addr1)).to.equal(5);
+                expect(await fund.trancheBalanceOf(TRANCHE_M, addr1)).to.equal(oldM);
+                expect(await fund.trancheBalanceOf(TRANCHE_A, addr1)).to.equal(oldA);
+                expect(await fund.trancheBalanceOf(TRANCHE_B, addr1)).to.equal(oldB);
             });
 
             it("Zero targetVersion", async function () {
                 await preDefinedRebalance070();
                 await preDefinedRebalance200();
                 await preDefinedRebalance170();
-                const oldM = await fund.shareBalanceOf(TRANCHE_M, addr1);
-                const oldA = await fund.shareBalanceOf(TRANCHE_A, addr1);
-                const oldB = await fund.shareBalanceOf(TRANCHE_B, addr1);
+                const oldM = await fund.trancheBalanceOf(TRANCHE_M, addr1);
+                const oldA = await fund.trancheBalanceOf(TRANCHE_A, addr1);
+                const oldB = await fund.trancheBalanceOf(TRANCHE_B, addr1);
                 await fund.refreshBalance(addr1, 0);
-                expect(await fund.shareBalanceVersion(addr1)).to.equal(3);
-                expect(await fund.shareBalanceOf(TRANCHE_M, addr1)).to.equal(oldM);
-                expect(await fund.shareBalanceOf(TRANCHE_A, addr1)).to.equal(oldA);
-                expect(await fund.shareBalanceOf(TRANCHE_B, addr1)).to.equal(oldB);
+                expect(await fund.trancheBalanceVersion(addr1)).to.equal(3);
+                expect(await fund.trancheBalanceOf(TRANCHE_M, addr1)).to.equal(oldM);
+                expect(await fund.trancheBalanceOf(TRANCHE_A, addr1)).to.equal(oldA);
+                expect(await fund.trancheBalanceOf(TRANCHE_B, addr1)).to.equal(oldB);
             });
 
             it("Should make no change if targetVersion is older", async function () {
                 await preDefinedRebalance070();
                 await preDefinedRebalance200();
                 await preDefinedRebalance170();
-                const oldM = await fund.shareBalanceOf(TRANCHE_M, addr1);
-                const oldA = await fund.shareBalanceOf(TRANCHE_A, addr1);
-                const oldB = await fund.shareBalanceOf(TRANCHE_B, addr1);
+                const oldM = await fund.trancheBalanceOf(TRANCHE_M, addr1);
+                const oldA = await fund.trancheBalanceOf(TRANCHE_A, addr1);
+                const oldB = await fund.trancheBalanceOf(TRANCHE_B, addr1);
                 await fund.refreshBalance(addr1, 3);
                 await fund.refreshBalance(addr1, 1);
-                expect(await fund.shareBalanceVersion(addr1)).to.equal(3);
-                expect(await fund.shareBalanceOf(TRANCHE_M, addr1)).to.equal(oldM);
-                expect(await fund.shareBalanceOf(TRANCHE_A, addr1)).to.equal(oldA);
-                expect(await fund.shareBalanceOf(TRANCHE_B, addr1)).to.equal(oldB);
+                expect(await fund.trancheBalanceVersion(addr1)).to.equal(3);
+                expect(await fund.trancheBalanceOf(TRANCHE_M, addr1)).to.equal(oldM);
+                expect(await fund.trancheBalanceOf(TRANCHE_A, addr1)).to.equal(oldA);
+                expect(await fund.trancheBalanceOf(TRANCHE_B, addr1)).to.equal(oldB);
             });
         });
     });

--- a/test/primaryMarketV3.ts
+++ b/test/primaryMarketV3.ts
@@ -101,7 +101,7 @@ describe("PrimaryMarketV3", function () {
         });
 
         it("Should transfer underlying from msg.sender", async function () {
-            await fund.mock.mint.returns();
+            await fund.mock.primaryMarketMint.returns();
             await expect(() => primaryMarket.create(addr2, inBtc, 0, 0)).to.changeTokenBalances(
                 btc,
                 [user1, fund],
@@ -112,17 +112,17 @@ describe("PrimaryMarketV3", function () {
         it("Should mint shares to the given recipient", async function () {
             const version = 999;
             await expect(() => primaryMarket.create(addr2, inBtc, 0, version)).to.callMocks({
-                func: fund.mock.mint.withArgs(TRANCHE_M, addr2, outM, version),
+                func: fund.mock.primaryMarketMint.withArgs(TRANCHE_M, addr2, outM, version),
             });
         });
 
         it("Should return created share amount", async function () {
-            await fund.mock.mint.returns();
+            await fund.mock.primaryMarketMint.returns();
             expect(await primaryMarket.callStatic.create(addr2, inBtc, 0, 0)).to.equal(outM);
         });
 
         it("Should check min shares created", async function () {
-            await fund.mock.mint.returns();
+            await fund.mock.primaryMarketMint.returns();
             await expect(primaryMarket.create(addr2, inBtc, outM.add(1), 0)).to.be.revertedWith(
                 "Min shares created"
             );
@@ -130,7 +130,7 @@ describe("PrimaryMarketV3", function () {
         });
 
         it("Should revert if no share can be created", async function () {
-            await fund.mock.mint.returns();
+            await fund.mock.primaryMarketMint.returns();
             await fund.mock.getTotalShares.returns(1);
             await fund.mock.getTotalUnderlying.returns(parseBtc("10"));
             await expect(primaryMarket.create(addr2, parseBtc("1"), 0, 0)).to.be.revertedWith(
@@ -139,7 +139,7 @@ describe("PrimaryMarketV3", function () {
         });
 
         it("Should check fund cap", async function () {
-            await fund.mock.mint.returns();
+            await fund.mock.primaryMarketMint.returns();
             await primaryMarket.connect(owner).updateFundCap(TOTAL_UNDERLYING.add(inBtc).sub(1));
             await expect(primaryMarket.create(addr2, inBtc, 0, 0)).to.be.revertedWith(
                 "Exceed fund cap"
@@ -159,14 +159,14 @@ describe("PrimaryMarketV3", function () {
             await fund.mock.historicalNavs
                 .withArgs(currentDay - DAY)
                 .returns(parseEther("0.5"), 0, 0);
-            await fund.mock.mint.returns();
+            await fund.mock.primaryMarketMint.returns();
             expect(await primaryMarket.callStatic.create(addr2, inBtc, 0, 0)).equal(
                 parseEther("60000")
             );
         });
 
         it("Should emit an event", async function () {
-            await fund.mock.mint.returns();
+            await fund.mock.primaryMarketMint.returns();
             await expect(primaryMarket.create(addr2, inBtc, 0, 0))
                 .to.emit(primaryMarket, "Created")
                 .withArgs(addr2, inBtc, outM);
@@ -193,7 +193,7 @@ describe("PrimaryMarketV3", function () {
             const version = 999;
             await expect(() => primaryMarket.redeem(addr2, inM, 0, version)).to.callMocks(
                 {
-                    func: fund.mock.burn.withArgs(TRANCHE_M, addr1, inM, version),
+                    func: fund.mock.primaryMarketBurn.withArgs(TRANCHE_M, addr1, inM, version),
                 },
                 {
                     func: fund.mock.primaryMarketTransferUnderlying.withArgs(addr2, outBtc, feeBtc),
@@ -202,13 +202,13 @@ describe("PrimaryMarketV3", function () {
         });
 
         it("Should return redeemed underlying amount", async function () {
-            await fund.mock.burn.returns();
+            await fund.mock.primaryMarketBurn.returns();
             await fund.mock.primaryMarketTransferUnderlying.returns();
             expect(await primaryMarket.callStatic.redeem(addr2, inM, 0, 0)).to.equal(outBtc);
         });
 
         it("Should check min underlying redeemed", async function () {
-            await fund.mock.burn.returns();
+            await fund.mock.primaryMarketBurn.returns();
             await fund.mock.primaryMarketTransferUnderlying.returns();
             await expect(primaryMarket.redeem(addr2, inM, outBtc.add(1), 0)).to.be.revertedWith(
                 "Min underlying redeemed"
@@ -217,7 +217,7 @@ describe("PrimaryMarketV3", function () {
         });
 
         it("Should revert if no share can be created", async function () {
-            await fund.mock.burn.returns();
+            await fund.mock.primaryMarketBurn.returns();
             await fund.mock.primaryMarketTransferUnderlying.returns();
             await fund.mock.getTotalShares.returns(parseEther("10000"));
             await fund.mock.getTotalUnderlying.returns(1);
@@ -228,7 +228,7 @@ describe("PrimaryMarketV3", function () {
 
         it("Should revert on not enough available hot balance", async function () {
             await btc.burn(fund.address, TOTAL_UNDERLYING);
-            await fund.mock.burn.returns();
+            await fund.mock.primaryMarketBurn.returns();
             await fund.mock.primaryMarketTransferUnderlying.returns();
 
             await btc.mint(fund.address, outBtc.sub(1));
@@ -240,7 +240,7 @@ describe("PrimaryMarketV3", function () {
         });
 
         it("Should emit an event", async function () {
-            await fund.mock.burn.returns();
+            await fund.mock.primaryMarketBurn.returns();
             await fund.mock.primaryMarketTransferUnderlying.returns();
             await expect(primaryMarket.redeem(addr2, inM, outBtc, 0))
                 .to.emit(primaryMarket, "Redeemed")
@@ -261,20 +261,20 @@ describe("PrimaryMarketV3", function () {
             const version = 999;
             await expect(() => primaryMarket.split(addr2, inM, version)).to.callMocks(
                 {
-                    func: fund.mock.burn.withArgs(TRANCHE_M, addr1, inM, version),
+                    func: fund.mock.primaryMarketBurn.withArgs(TRANCHE_M, addr1, inM, version),
                 },
                 {
-                    func: fund.mock.mint.withArgs(TRANCHE_A, addr2, outAB, version),
+                    func: fund.mock.primaryMarketMint.withArgs(TRANCHE_A, addr2, outAB, version),
                 },
                 {
-                    func: fund.mock.mint.withArgs(TRANCHE_B, addr2, outAB, version),
+                    func: fund.mock.primaryMarketMint.withArgs(TRANCHE_B, addr2, outAB, version),
                 }
             );
         });
 
         it("Should return split amount", async function () {
-            await fund.mock.burn.returns();
-            await fund.mock.mint.returns();
+            await fund.mock.primaryMarketBurn.returns();
+            await fund.mock.primaryMarketMint.returns();
             expect(await primaryMarket.callStatic.split(addr2, 0, 0)).to.equal(0);
             expect(await primaryMarket.callStatic.split(addr2, 1, 0)).to.equal(0);
             expect(await primaryMarket.callStatic.split(addr2, 2, 0)).to.equal(1);
@@ -282,8 +282,8 @@ describe("PrimaryMarketV3", function () {
         });
 
         it("Should emit an event", async function () {
-            await fund.mock.burn.returns();
-            await fund.mock.mint.returns();
+            await fund.mock.primaryMarketBurn.returns();
+            await fund.mock.primaryMarketMint.returns();
             await expect(primaryMarket.split(addr2, inM, 0))
                 .to.emit(primaryMarket, "Split")
                 .withArgs(addr2, inM, outAB, outAB);
@@ -307,13 +307,13 @@ describe("PrimaryMarketV3", function () {
             const version = 999;
             await expect(() => primaryMarket.merge(addr2, inAB, version)).to.callMocks(
                 {
-                    func: fund.mock.burn.withArgs(TRANCHE_A, addr1, inAB, version),
+                    func: fund.mock.primaryMarketBurn.withArgs(TRANCHE_A, addr1, inAB, version),
                 },
                 {
-                    func: fund.mock.burn.withArgs(TRANCHE_B, addr1, inAB, version),
+                    func: fund.mock.primaryMarketBurn.withArgs(TRANCHE_B, addr1, inAB, version),
                 },
                 {
-                    func: fund.mock.mint.withArgs(TRANCHE_M, addr2, outM, version),
+                    func: fund.mock.primaryMarketMint.withArgs(TRANCHE_M, addr2, outM, version),
                 },
                 {
                     func: fund.mock.primaryMarketAddDebt.withArgs(0, feeBtc),
@@ -322,8 +322,8 @@ describe("PrimaryMarketV3", function () {
         });
 
         it("Should return merged amount", async function () {
-            await fund.mock.burn.returns();
-            await fund.mock.mint.returns();
+            await fund.mock.primaryMarketBurn.returns();
+            await fund.mock.primaryMarketMint.returns();
             await fund.mock.primaryMarketAddDebt.returns();
             expect(await primaryMarket.callStatic.merge(addr2, 0, 0)).to.equal(0);
             expect(await primaryMarket.callStatic.merge(addr2, 1, 0)).to.equal(2);
@@ -331,8 +331,8 @@ describe("PrimaryMarketV3", function () {
         });
 
         it("Should emit an event", async function () {
-            await fund.mock.burn.returns();
-            await fund.mock.mint.returns();
+            await fund.mock.primaryMarketBurn.returns();
+            await fund.mock.primaryMarketMint.returns();
             await fund.mock.primaryMarketAddDebt.returns();
             await expect(primaryMarket.merge(addr2, inAB, 0))
                 .to.emit(primaryMarket, "Merged")
@@ -360,7 +360,7 @@ describe("PrimaryMarketV3", function () {
             const version = 999;
             await expect(() => primaryMarket.queueRedemption(addr2, inM, 0, version)).to.callMocks(
                 {
-                    func: fund.mock.burn.withArgs(TRANCHE_M, addr1, inM, version),
+                    func: fund.mock.primaryMarketBurn.withArgs(TRANCHE_M, addr1, inM, version),
                 },
                 {
                     func: fund.mock.primaryMarketAddDebt.withArgs(outBtc, feeBtc),
@@ -369,14 +369,14 @@ describe("PrimaryMarketV3", function () {
         });
 
         it("Should return redeemed underlying amount", async function () {
-            await fund.mock.burn.returns();
+            await fund.mock.primaryMarketBurn.returns();
             await fund.mock.primaryMarketAddDebt.returns();
             const ret = await primaryMarket.callStatic.queueRedemption(addr2, inM, 0, 0);
             expect(ret.underlying).to.equal(outBtc);
         });
 
         it("Should check min underlying redeemed", async function () {
-            await fund.mock.burn.returns();
+            await fund.mock.primaryMarketBurn.returns();
             await fund.mock.primaryMarketAddDebt.returns();
             await expect(
                 primaryMarket.queueRedemption(addr2, inM, outBtc.add(1), 0)
@@ -385,7 +385,7 @@ describe("PrimaryMarketV3", function () {
         });
 
         it("Should revert if no share can be created", async function () {
-            await fund.mock.burn.returns();
+            await fund.mock.primaryMarketBurn.returns();
             await fund.mock.primaryMarketAddDebt.returns();
             await fund.mock.getTotalShares.returns(parseEther("10000"));
             await fund.mock.getTotalUnderlying.returns(1);
@@ -395,7 +395,7 @@ describe("PrimaryMarketV3", function () {
         });
 
         it("Should return index in the queue", async function () {
-            await fund.mock.burn.returns();
+            await fund.mock.primaryMarketBurn.returns();
             await fund.mock.primaryMarketAddDebt.returns();
             const ret0 = await primaryMarket.callStatic.queueRedemption(addr2, inM, 0, 0);
             expect(ret0.index).to.equal(0);
@@ -406,7 +406,7 @@ describe("PrimaryMarketV3", function () {
         });
 
         it("Should append redemption to the queue", async function () {
-            await fund.mock.burn.returns();
+            await fund.mock.primaryMarketBurn.returns();
             await fund.mock.primaryMarketAddDebt.returns();
 
             await primaryMarket.queueRedemption(addr2, inM, 0, 0);
@@ -429,7 +429,7 @@ describe("PrimaryMarketV3", function () {
         });
 
         it("Should emit Redeemed event", async function () {
-            await fund.mock.burn.returns();
+            await fund.mock.primaryMarketBurn.returns();
             await fund.mock.primaryMarketAddDebt.returns();
             await expect(primaryMarket.queueRedemption(addr2, inM, outBtc, 0))
                 .to.emit(primaryMarket, "Redeemed")
@@ -437,7 +437,7 @@ describe("PrimaryMarketV3", function () {
         });
 
         it("Should emit RedemptionQueued event", async function () {
-            await fund.mock.burn.returns();
+            await fund.mock.primaryMarketBurn.returns();
             await fund.mock.primaryMarketAddDebt.returns();
             await primaryMarket.queueRedemption(addr2, inM.mul(2), 0, 0);
             await expect(primaryMarket.queueRedemption(addr2, inM, 0, 0))
@@ -451,7 +451,7 @@ describe("PrimaryMarketV3", function () {
         const outPrefixSum: BigNumber[] = [];
 
         beforeEach(async function () {
-            await fund.mock.burn.returns();
+            await fund.mock.primaryMarketBurn.returns();
             await fund.mock.primaryMarketAddDebt.returns();
             await btc.burn(fund.address, TOTAL_UNDERLYING); // Remove all underlying from the fund
             const inputList = [
@@ -702,7 +702,7 @@ describe("PrimaryMarketV3", function () {
             await btc.burn(fund.address, TOTAL_UNDERLYING); // clear btc minted before
             await btc.mint(fund.address, BIG_UNIT.mul(15));
 
-            await fund.mock.burn.returns();
+            await fund.mock.primaryMarketBurn.returns();
             await fund.mock.primaryMarketAddDebt.returns();
             await primaryMarket.queueRedemption(addr2, 3, 0, 0); // prefix sum: 3
             await primaryMarket.queueRedemption(addr2, 3, 0, 0); // prefix sum: 6
@@ -808,7 +808,7 @@ describe("PrimaryMarketV3", function () {
             const inEth = parseEther("1");
             const outM = inEth.mul(TOTAL_SHARES).div(ETH_TOTAL_UNDERLYING);
             const version = 999;
-            await fund.mock.mint.withArgs(TRANCHE_M, addr2, outM, version).returns();
+            await fund.mock.primaryMarketMint.withArgs(TRANCHE_M, addr2, outM, version).returns();
             expect(
                 await primaryMarket.callStatic.wrapAndCreate(addr2, 0, version, { value: inEth })
             ).to.equal(outM);
@@ -831,7 +831,7 @@ describe("PrimaryMarketV3", function () {
             await weth.connect(owner).deposit({ value: outEth.mul(2) });
             await weth.connect(owner).transfer(primaryMarket.address, outEth);
             await weth.connect(owner).transfer(fund.address, outEth);
-            await fund.mock.burn.withArgs(TRANCHE_M, addr1, inM, version).returns();
+            await fund.mock.primaryMarketBurn.withArgs(TRANCHE_M, addr1, inM, version).returns();
             await fund.mock.primaryMarketTransferUnderlying
                 .withArgs(primaryMarket.address, outEth, feeEth)
                 .returns();
@@ -855,7 +855,7 @@ describe("PrimaryMarketV3", function () {
             await weth.connect(owner).deposit({ value: outEth.mul(2) });
             await weth.connect(owner).transfer(primaryMarket.address, outEth);
             await weth.connect(owner).transfer(fund.address, outEth);
-            await fund.mock.burn.returns();
+            await fund.mock.primaryMarketBurn.returns();
             await fund.mock.primaryMarketAddDebt.returns();
             await primaryMarket.queueRedemption(addr2, inM, 0, 0);
 


### PR DESCRIPTION
* `mint` -> `primaryMarketMint`
* `burn` -> `primaryMarketBurn`
* `shareBalanceOf` -> `trancheBalanceOf`
* `allShareBalanceOf` -> `trancheAllBalanceOf`
* `shareBalanceVersion` -> `trancheBalanceVersion`
* `shareAllowance` -> `trancheAllowance`
* `shareAllowanceVersion` -> `trancheAllowanceVersion`
* `shareTotalSupply` -> `trancheTotalSupply`
* `transfer` -> `shareTransfer`
* `transferFrom` -> `shareTransferFrom`
* `approve` -> `shareApprove`
* `increaseAllowance` -> `shareIncreaseAllowance`
* `decreaseAllowance` -> `shareDecreaseAllowance`