### PR TITLE
Add additional fields in the FundV3.Settled event to enable `extrapolateNav` off-chain

### DIFF
--- a/contracts/fund/FundV3.sol
+++ b/contracts/fund/FundV3.sol
@@ -841,7 +841,7 @@ contract FundV3 is IFundV3, Ownable, ReentrancyGuard, FundRolesV2, CoreUtility {
         _historicalNavR[day] = navR;
         currentDay = day + 1 days;
 
-        emit Settled(day, underlying, navB, navR, interestRate);
+        emit Settled(day, navB, navR, interestRate);
     }
 
     function transferToStrategy(uint256 amount) external override onlyStrategy {

--- a/contracts/fund/FundV3.sol
+++ b/contracts/fund/FundV3.sol
@@ -37,6 +37,7 @@ contract FundV3 is IFundV3, Ownable, ReentrancyGuard, FundRolesV2, CoreUtility {
     event BallotUpdated(address newBallot);
     event FeeCollectorUpdated(address newFeeCollector);
     event ActivityDelayTimeUpdated(uint256 delayTime);
+    event SplitRatioUpdated(uint256 newSplitRatio);
 
     uint256 private constant UNIT = 1e18;
     uint256 private constant MAX_INTEREST_RATE = 0.2e18; // 20% daily
@@ -79,7 +80,7 @@ contract FundV3 is IFundV3, Ownable, ReentrancyGuard, FundRolesV2, CoreUtility {
 
     /// @notice The amount of BISHOP received by splitting one QUEEN.
     ///         This ratio changes on every rebalance.
-    uint256 public override splitRatio; // TODO need event?
+    uint256 public override splitRatio;
 
     /// @notice Start timestamp of the current primary market activity window.
     uint256 public override fundActivityStartTime;
@@ -201,6 +202,7 @@ contract FundV3 is IFundV3, Ownable, ReentrancyGuard, FundRolesV2, CoreUtility {
         );
         currentDay = endOfDay(block.timestamp);
         splitRatio = newSplitRatio;
+        emit SplitRatioUpdated(newSplitRatio);
         uint256 lastDay = currentDay - 1 days;
         uint256 lastDayPrice = twapOracle.getTwap(lastDay);
         require(lastDayPrice != 0, "Price not available"); // required to do the first creation
@@ -818,6 +820,7 @@ contract FundV3 is IFundV3, Ownable, ReentrancyGuard, FundRolesV2, CoreUtility {
             uint256 newSplitRatio = splitRatio.multiplyDecimal(navSum) / 2;
             _triggerRebalance(day, navSum, navB, navR, newSplitRatio);
             splitRatio = newSplitRatio;
+            emit SplitRatioUpdated(newSplitRatio);
             navB = UNIT;
             navR = UNIT;
             equivalentTotalB = getEquivalentTotalB();

--- a/contracts/fund/FundV3.sol
+++ b/contracts/fund/FundV3.sol
@@ -829,9 +829,11 @@ contract FundV3 is IFundV3, Ownable, ReentrancyGuard, FundRolesV2, CoreUtility {
             fundActivityStartTime = day;
         }
 
-        historicalInterestRate[day] = day == _endOfWeek(day - 1 days)
-            ? _updateInterestRate(day)
-            : historicalInterestRate[day - 1 days];
+        uint256 interestRate =
+            day == _endOfWeek(day - 1 days)
+                ? _updateInterestRate(day)
+                : historicalInterestRate[day - 1 days];
+        historicalInterestRate[day] = interestRate;
 
         historicalEquivalentTotalB[day] = equivalentTotalB;
         historicalUnderlying[day] = underlying;
@@ -839,7 +841,7 @@ contract FundV3 is IFundV3, Ownable, ReentrancyGuard, FundRolesV2, CoreUtility {
         _historicalNavR[day] = navR;
         currentDay = day + 1 days;
 
-        emit Settled(day, navB, navR);
+        emit Settled(day, underlying, navB, navR, interestRate);
     }
 
     function transferToStrategy(uint256 amount) external override onlyStrategy {

--- a/contracts/fund/FundV3.sol
+++ b/contracts/fund/FundV3.sol
@@ -38,6 +38,7 @@ contract FundV3 is IFundV3, Ownable, ReentrancyGuard, FundRolesV2, CoreUtility {
     event FeeCollectorUpdated(address newFeeCollector);
     event ActivityDelayTimeUpdated(uint256 delayTime);
     event SplitRatioUpdated(uint256 newSplitRatio);
+    event FeeDebtPaid(uint256 amount);
 
     uint256 private constant UNIT = 1e18;
     uint256 private constant MAX_INTEREST_RATE = 0.2e18; // 20% daily
@@ -1000,6 +1001,7 @@ contract FundV3 is IFundV3, Ownable, ReentrancyGuard, FundRolesV2, CoreUtility {
             feeDebt = fee - amount;
             _totalDebt = total - amount;
             IERC20(tokenUnderlying).safeTransfer(feeCollector, amount);
+            emit FeeDebtPaid(amount);
         }
     }
 

--- a/contracts/fund/PrimaryMarketV3.sol
+++ b/contracts/fund/PrimaryMarketV3.sol
@@ -19,9 +19,9 @@ contract PrimaryMarketV3 is IPrimaryMarketV3, ReentrancyGuard, ITrancheIndexV2, 
     event Created(address indexed account, uint256 underlying, uint256 outQ);
     event Redeemed(address indexed account, uint256 inQ, uint256 underlying, uint256 fee);
     event Split(address indexed account, uint256 inQ, uint256 outB, uint256 outR);
-    event Merged(address indexed account, uint256 outQ, uint256 inB, uint256 inR);
+    event Merged(address indexed account, uint256 outQ, uint256 inB, uint256 inR, uint256 feeQ);
     event RedemptionQueued(address indexed account, uint256 index, uint256 underlying);
-    event RedemptionPopped(uint256 count, uint256 newHead);
+    event RedemptionPopped(uint256 count, uint256 newHead, uint256 requiredUnderlying);
     event RedemptionClaimed(address indexed account, uint256 index, uint256 underlying);
     event FundCapUpdated(uint256 newCap);
     event RedemptionFeeRateUpdated(uint256 newRedemptionFeeRate);
@@ -469,7 +469,7 @@ contract PrimaryMarketV3 is IPrimaryMarketV3, ReentrancyGuard, ITrancheIndexV2, 
         );
         fund.primaryMarketPayDebt(requiredUnderlying);
         redemptionQueueHead = newHead;
-        emit RedemptionPopped(newHead - oldHead, newHead);
+        emit RedemptionPopped(newHead - oldHead, newHead, requiredUnderlying);
     }
 
     /// @notice Claim underlying tokens of queued redemptions. All these redemptions must
@@ -553,7 +553,7 @@ contract PrimaryMarketV3 is IPrimaryMarketV3, ReentrancyGuard, ITrancheIndexV2, 
         fund.primaryMarketBurn(TRANCHE_R, msg.sender, inB, version);
         fund.primaryMarketMint(TRANCHE_Q, recipient, outQ, version);
         fund.primaryMarketAddDebt(0, _getRedemptionBeforeFee(feeQ));
-        emit Merged(recipient, outQ, inB, inB);
+        emit Merged(recipient, outQ, inB, inB, feeQ);
     }
 
     /// @dev Nothing to do for daily fund settlement.

--- a/contracts/fund/PrimaryMarketV3.sol
+++ b/contracts/fund/PrimaryMarketV3.sol
@@ -19,7 +19,13 @@ contract PrimaryMarketV3 is IPrimaryMarketV3, ReentrancyGuard, ITrancheIndexV2, 
     event Created(address indexed account, uint256 underlying, uint256 outQ);
     event Redeemed(address indexed account, uint256 inQ, uint256 underlying, uint256 fee);
     event Split(address indexed account, uint256 inQ, uint256 outB, uint256 outR);
-    event Merged(address indexed account, uint256 outQ, uint256 inB, uint256 inR, uint256 feeQ);
+    event Merged(
+        address indexed account,
+        uint256 outQ,
+        uint256 inB,
+        uint256 inR,
+        uint256 underlying
+    );
     event RedemptionQueued(address indexed account, uint256 index, uint256 underlying);
     event RedemptionPopped(uint256 count, uint256 newHead, uint256 requiredUnderlying);
     event RedemptionClaimed(address indexed account, uint256 index, uint256 underlying);
@@ -552,8 +558,9 @@ contract PrimaryMarketV3 is IPrimaryMarketV3, ReentrancyGuard, ITrancheIndexV2, 
         fund.primaryMarketBurn(TRANCHE_B, msg.sender, inB, version);
         fund.primaryMarketBurn(TRANCHE_R, msg.sender, inB, version);
         fund.primaryMarketMint(TRANCHE_Q, recipient, outQ, version);
-        fund.primaryMarketAddDebt(0, _getRedemptionBeforeFee(feeQ));
-        emit Merged(recipient, outQ, inB, inB, feeQ);
+        uint256 feeUnderlying = _getRedemptionBeforeFee(feeQ);
+        fund.primaryMarketAddDebt(0, feeUnderlying);
+        emit Merged(recipient, outQ, inB, inB, feeUnderlying);
     }
 
     /// @dev Nothing to do for daily fund settlement.

--- a/contracts/fund/PrimaryMarketV3.sol
+++ b/contracts/fund/PrimaryMarketV3.sol
@@ -24,7 +24,7 @@ contract PrimaryMarketV3 is IPrimaryMarketV3, ReentrancyGuard, ITrancheIndexV2, 
         uint256 outQ,
         uint256 inB,
         uint256 inR,
-        uint256 underlying
+        uint256 feeUnderlying
     );
     event RedemptionQueued(address indexed account, uint256 index, uint256 underlying);
     event RedemptionPopped(uint256 count, uint256 newHead, uint256 requiredUnderlying);

--- a/contracts/interfaces/IFundV3.sol
+++ b/contracts/interfaces/IFundV3.sol
@@ -250,7 +250,7 @@ interface IFundV3 {
         uint256 ratioR2Q,
         uint256 ratioBR
     );
-    event Settled(uint256 indexed day, uint256 navB, uint256 navR);
+    event Settled(uint256 indexed day, uint256 underlying, uint256 navB, uint256 navR, uint256 interestRate);
     event InterestRateUpdated(uint256 baseInterestRate, uint256 floatingInterestRate);
     event BalancesRebalanced(
         address indexed account,

--- a/contracts/interfaces/IFundV3.sol
+++ b/contracts/interfaces/IFundV3.sol
@@ -250,7 +250,13 @@ interface IFundV3 {
         uint256 ratioR2Q,
         uint256 ratioBR
     );
-    event Settled(uint256 indexed day, uint256 underlying, uint256 navB, uint256 navR, uint256 interestRate);
+    event Settled(
+        uint256 indexed day,
+        uint256 underlying,
+        uint256 navB,
+        uint256 navR,
+        uint256 interestRate
+    );
     event InterestRateUpdated(uint256 baseInterestRate, uint256 floatingInterestRate);
     event BalancesRebalanced(
         address indexed account,

--- a/contracts/interfaces/IFundV3.sol
+++ b/contracts/interfaces/IFundV3.sol
@@ -250,13 +250,7 @@ interface IFundV3 {
         uint256 ratioR2Q,
         uint256 ratioBR
     );
-    event Settled(
-        uint256 indexed day,
-        uint256 underlying,
-        uint256 navB,
-        uint256 navR,
-        uint256 interestRate
-    );
+    event Settled(uint256 indexed day, uint256 navB, uint256 navR, uint256 interestRate);
     event InterestRateUpdated(uint256 baseInterestRate, uint256 floatingInterestRate);
     event BalancesRebalanced(
         address indexed account,

--- a/test/fundV3.ts
+++ b/test/fundV3.ts
@@ -709,7 +709,13 @@ describe("FundV3", function () {
             await advanceBlockAtTime(startDay);
             await expect(fund.settle())
                 .to.emit(fund, "Settled")
-                .withArgs(startDay, parseEther("1"), parseEther("1"));
+                .withArgs(
+                    startDay,
+                    parseEther("0"),
+                    parseEther("1"),
+                    parseEther("1"),
+                    parseEther("0.001")
+                );
             expect(await fund.currentDay()).to.equal(startDay + DAY);
             expect(await fund.getRebalanceSize()).to.equal(0);
             const navs = await fund.historicalNavs(startDay);
@@ -741,8 +747,11 @@ describe("FundV3", function () {
                 .mul(2)
                 .div(totalShares);
             const navR = navSum.sub(navB);
+            const interestRate = parseEther("0.001");
             await advanceBlockAtTime(startDay);
-            await expect(fund.settle()).to.emit(fund, "Settled").withArgs(startDay, navB, navR);
+            await expect(fund.settle())
+                .to.emit(fund, "Settled")
+                .withArgs(startDay, btcInFund, navB, navR, interestRate);
             expect(await fund.currentDay()).to.equal(startDay + DAY);
             expect(await fund.getRebalanceSize()).to.equal(0);
             const navs = await fund.historicalNavs(startDay);

--- a/test/fundV3.ts
+++ b/test/fundV3.ts
@@ -707,15 +707,10 @@ describe("FundV3", function () {
         it("Should keep previous NAV when nothing happened", async function () {
             await twapOracle.mock.getTwap.returns(parseEther("1100"));
             await advanceBlockAtTime(startDay);
+            const interestRate = parseEther("0.001");
             await expect(fund.settle())
                 .to.emit(fund, "Settled")
-                .withArgs(
-                    startDay,
-                    parseEther("0"),
-                    parseEther("1"),
-                    parseEther("1"),
-                    parseEther("0.001")
-                );
+                .withArgs(startDay, parseEther("1"), parseEther("1"), interestRate);
             expect(await fund.currentDay()).to.equal(startDay + DAY);
             expect(await fund.getRebalanceSize()).to.equal(0);
             const navs = await fund.historicalNavs(startDay);
@@ -751,7 +746,7 @@ describe("FundV3", function () {
             await advanceBlockAtTime(startDay);
             await expect(fund.settle())
                 .to.emit(fund, "Settled")
-                .withArgs(startDay, btcInFund, navB, navR, interestRate);
+                .withArgs(startDay, navB, navR, interestRate);
             expect(await fund.currentDay()).to.equal(startDay + DAY);
             expect(await fund.getRebalanceSize()).to.equal(0);
             const navs = await fund.historicalNavs(startDay);

--- a/test/primaryMarketV3.ts
+++ b/test/primaryMarketV3.ts
@@ -364,7 +364,7 @@ describe("PrimaryMarketV3", function () {
             await fund.mock.primaryMarketAddDebt.returns();
             await expect(primaryMarket.merge(addr2, inB, 0))
                 .to.emit(primaryMarket, "Merged")
-                .withArgs(addr2, outQ, inB, inB, feeQ);
+                .withArgs(addr2, outQ, inB, inB, feeBtc);
         });
     });
 

--- a/test/primaryMarketV3.ts
+++ b/test/primaryMarketV3.ts
@@ -364,7 +364,7 @@ describe("PrimaryMarketV3", function () {
             await fund.mock.primaryMarketAddDebt.returns();
             await expect(primaryMarket.merge(addr2, inB, 0))
                 .to.emit(primaryMarket, "Merged")
-                .withArgs(addr2, outQ, inB, inB);
+                .withArgs(addr2, outQ, inB, inB, feeQ);
         });
     });
 
@@ -660,10 +660,10 @@ describe("PrimaryMarketV3", function () {
                 await btc.mint(fund.address, TOTAL_UNDERLYING);
                 await expect(primaryMarket.popRedemptionQueue(2))
                     .to.emit(primaryMarket, "RedemptionPopped")
-                    .withArgs(2, 2);
+                    .withArgs(2, 2, outPrefixSum[1]);
                 await expect(primaryMarket.popRedemptionQueue(2))
                     .to.emit(primaryMarket, "RedemptionPopped")
-                    .withArgs(2, 4);
+                    .withArgs(2, 4, outPrefixSum[3].sub(outPrefixSum[1]));
             });
         });
 


### PR DESCRIPTION
Rational that we can compute `extrapolateNav()` off-chain at any historical time:

- `extrapolateNav` requires `price`, `getTotalUnderlying()`, `dailyProtocolFeeRate`, `getEquivalentTotalB()` and `_extrapolateNav()`.
- When computing off-chain, we use the TWAP price for `price`.
- There is already `DailyProtocolFeeRateUpdated()` event, so we can compute `dailyProtocolFeeRate`.
- `_extrapolateNav()` requires historical `navB`, `navR` and `historicalInterestRate` at the settled day, *which are added in the PR`.

## `getEquivalentTotalB()`

- `getEquivalentTotalB()` requires the total supply of Tranche Q and B, and `splitRatio`.
- **Add `SplitRatioUpdated()` event in this PR**. Thus, we can compute `splitRatio`.
- `_totalSupplies` changes during mint, burn and rebalance.
- In case of mint and burn, we use `ShareV2.Transfer()` events to recover the supply changes.
- In case of rebalance, we use `RebalanceTriggered()` events.

## `getTotalUnderlying`

- `getTotalUnderlying()` requires the balance of the underlying of the fund, `_strategyUnderlying` and `_totalDebt`.
- The fund's balance can be read from `ERC20.Transfer` events associated with the fund.
- `_strategyUnderlying` can be recovered from `ERC20.Trasfer` events between the the fund and the strategy.

### `_totalDebt`

- `_totalDebt` changes in one of the following functions: `_collectFee()`, `_payFeeDebt()`, `reportProfit()`, `primaryMarketTransferUnderlying()`, `primaryMarketAddDebt()`, `primaryMarketPayDebt()`.
- `_collectFee()` is called only from `settle()`, and the fee can be computed from the current underlying.
- `_payFeeDebt()` is called from `settle()` and `transferFromStrategy()`. **Add a new event `FeeDebtPaid`**.
- `reportProfit()` already has a dedicated event, which is ok.
- `primaryMarketTransferUnderlying()` is called from `PrimaryMarketV3.redeem`, and we can read the change from `PrimaryMarketV3.Redeemed()` events. Here's a caveat, when seeing a `PrimaryMarketV3.Redeemed()` event, if we see a `RedemptionQueued()` subsequently, it's `Fund.primaryMarketAddDebt()` being called instead of `primaryMarketTransferUnderlying()`. Anyway, we can distinguish the two different cases from previously emitted events. Though in either case, `balanceOf(fund) - totalDebt` changes in the same way. So there is no need to distinguish the two cases.
- `primaryMarketPayDebt()` is called from `PrimaryMarketV3._popRedemptionQueue()`. **Add `requiredUnderlying` to the event `PrimaryMarketV3.RedemptionPopped()`**.
- As mentioned above, `primaryMarketAddDebt()` is called from `redeem()`, also it's called from `merge()`. **Add `feeUnderlying` to the event `PrimaryMarketV3.Merged()``**. 