### PR TITLE
Added additional fields in the Fund.RebalanceTriggered event

### DIFF
--- a/contracts/fund/FundV3.sol
+++ b/contracts/fund/FundV3.sol
@@ -1040,6 +1040,9 @@ contract FundV3 is IFundV3, Ownable, ReentrancyGuard, FundRolesV2, CoreUtility {
         emit RebalanceTriggered(
             oldSize,
             day,
+            navSum,
+            navB,
+            navROrZero,
             rebalance.ratioB2Q,
             rebalance.ratioR2Q,
             rebalance.ratioBR

--- a/contracts/interfaces/IFundV3.sol
+++ b/contracts/interfaces/IFundV3.sol
@@ -246,6 +246,9 @@ interface IFundV3 {
     event RebalanceTriggered(
         uint256 indexed index,
         uint256 indexed day,
+        uint256 navSum,
+        uint256 nvB,
+        uint256 navROrZero,
         uint256 ratioB2Q,
         uint256 ratioR2Q,
         uint256 ratioBR

--- a/contracts/interfaces/IFundV3.sol
+++ b/contracts/interfaces/IFundV3.sol
@@ -247,7 +247,7 @@ interface IFundV3 {
         uint256 indexed index,
         uint256 indexed day,
         uint256 navSum,
-        uint256 nvB,
+        uint256 navB,
         uint256 navROrZero,
         uint256 ratioB2Q,
         uint256 ratioR2Q,

--- a/test/fundV3.ts
+++ b/test/fundV3.ts
@@ -766,7 +766,7 @@ describe("FundV3", function () {
             );
         });
 
-        it.only("Should success even if feeCollector.checkpoint() reverts", async function () {
+        it("Should success even if feeCollector.checkpoint() reverts", async function () {
             const feeCollector = await deployMockForName(owner, "FeeDistributor");
             await fund.connect(owner).updateFeeCollector(feeCollector.address);
             await feeCollector.mock.checkpoint.reverts();


### PR DESCRIPTION
Included `navSum`, `navB` and `navROrZero` in the `RebalanceTriggered` event.

Also, it enabled tests in `fundV3.tests` which is disabled by PR #142 by mistake.