### PR TITLE
Fixed the logic of PrimaryMarketV3.merge

### DIFF
--- a/contracts/fund/PrimaryMarketV3.sol
+++ b/contracts/fund/PrimaryMarketV3.sol
@@ -555,10 +555,10 @@ contract PrimaryMarketV3 is IPrimaryMarketV3, ReentrancyGuard, ITrancheIndexV2, 
     ) external override onlyActive returns (uint256 outQ) {
         uint256 feeQ;
         (outQ, feeQ) = getMerge(inB);
+        uint256 feeUnderlying = _getRedemptionBeforeFee(feeQ);
         fund.primaryMarketBurn(TRANCHE_B, msg.sender, inB, version);
         fund.primaryMarketBurn(TRANCHE_R, msg.sender, inB, version);
         fund.primaryMarketMint(TRANCHE_Q, recipient, outQ, version);
-        uint256 feeUnderlying = _getRedemptionBeforeFee(feeQ);
         fund.primaryMarketAddDebt(0, feeUnderlying);
         emit Merged(recipient, outQ, inB, inB, feeUnderlying);
     }


### PR DESCRIPTION
`_getRedemptionBeforeFee` relies on the total supplies of Q, B, R. Thus, it should be computed before the tokens are actually burned or minted.