### PR TITLE
Removed the `onlyActive` modifier in PrimaryMarketV3

### DIFF
--- a/contracts/fund/FundV3.sol
+++ b/contracts/fund/FundV3.sol
@@ -277,19 +277,6 @@ contract FundV3 is IFundV3, Ownable, ReentrancyGuard, FundRolesV2, CoreUtility {
         return timestamp >= fundActivityStartTime;
     }
 
-    /// @notice Return the status of a given primary market contract.
-    /// @param pm The primary market contract address
-    /// @param timestamp Timestamp to assess
-    /// @return True if the primary market contract is active
-    function isPrimaryMarketActive(address pm, uint256 timestamp)
-        public
-        view
-        override
-        returns (bool)
-    {
-        return pm == _primaryMarket && timestamp >= fundActivityStartTime && timestamp < currentDay;
-    }
-
     function getTotalUnderlying() public view override returns (uint256) {
         uint256 hot = IERC20(tokenUnderlying).balanceOf(address(this));
         return hot.add(_strategyUnderlying).sub(_totalDebt);

--- a/contracts/fund/FundV3.sol
+++ b/contracts/fund/FundV3.sol
@@ -670,8 +670,10 @@ contract FundV3 is IFundV3, Ownable, ReentrancyGuard, FundRolesV2, CoreUtility {
         address recipient,
         uint256 amount
     ) public override {
-        require(isFundActive(block.timestamp), "Transfer is inactive");
         uint256 tranche = _getTranche(msg.sender);
+        if (tranche != TRANCHE_Q) {
+            require(isFundActive(block.timestamp), "Transfer is inactive");
+        }
         _refreshBalance(sender, _rebalanceSize);
         _refreshBalance(recipient, _rebalanceSize);
         _transfer(tranche, sender, recipient, amount);

--- a/contracts/fund/PrimaryMarketV3.sol
+++ b/contracts/fund/PrimaryMarketV3.sol
@@ -383,7 +383,7 @@ contract PrimaryMarketV3 is IPrimaryMarketV3, ReentrancyGuard, ITrancheIndexV2, 
         uint256 underlying,
         uint256 minOutQ,
         uint256 version
-    ) private onlyActive returns (uint256 outQ) {
+    ) private returns (uint256 outQ) {
         outQ = getCreation(underlying);
         require(outQ >= minOutQ && outQ > 0, "Min QUEEN created");
         fund.primaryMarketMint(TRANCHE_Q, recipient, outQ, version);
@@ -395,7 +395,7 @@ contract PrimaryMarketV3 is IPrimaryMarketV3, ReentrancyGuard, ITrancheIndexV2, 
         uint256 inQ,
         uint256 minUnderlying,
         uint256 version
-    ) private onlyActive returns (uint256 underlying) {
+    ) private returns (uint256 underlying) {
         fund.primaryMarketBurn(TRANCHE_Q, msg.sender, inQ, version);
         _popRedemptionQueue(0);
         uint256 fee;
@@ -424,7 +424,7 @@ contract PrimaryMarketV3 is IPrimaryMarketV3, ReentrancyGuard, ITrancheIndexV2, 
         uint256 inQ,
         uint256 minUnderlying,
         uint256 version
-    ) external override onlyActive nonReentrant returns (uint256 underlying, uint256 index) {
+    ) external override nonReentrant returns (uint256 underlying, uint256 index) {
         fund.primaryMarketBurn(TRANCHE_Q, msg.sender, inQ, version);
         uint256 fee;
         (underlying, fee) = getRedemption(inQ);
@@ -540,7 +540,7 @@ contract PrimaryMarketV3 is IPrimaryMarketV3, ReentrancyGuard, ITrancheIndexV2, 
         address recipient,
         uint256 inQ,
         uint256 version
-    ) external override onlyActive returns (uint256 outB) {
+    ) external override returns (uint256 outB) {
         outB = getSplit(inQ);
         fund.primaryMarketBurn(TRANCHE_Q, msg.sender, inQ, version);
         fund.primaryMarketMint(TRANCHE_B, recipient, outB, version);
@@ -552,7 +552,7 @@ contract PrimaryMarketV3 is IPrimaryMarketV3, ReentrancyGuard, ITrancheIndexV2, 
         address recipient,
         uint256 inB,
         uint256 version
-    ) external override onlyActive returns (uint256 outQ) {
+    ) external override returns (uint256 outQ) {
         uint256 feeQ;
         (outQ, feeQ) = getMerge(inB);
         uint256 feeUnderlying = _getRedemptionBeforeFee(feeQ);
@@ -597,11 +597,6 @@ contract PrimaryMarketV3 is IPrimaryMarketV3, ReentrancyGuard, ITrancheIndexV2, 
 
     /// @notice Receive unwrapped transfer from the wrapped token.
     receive() external payable {}
-
-    modifier onlyActive() {
-        require(fund.isPrimaryMarketActive(address(this), block.timestamp), "Only when active");
-        _;
-    }
 
     modifier onlyFund() {
         require(msg.sender == address(fund), "Only fund");

--- a/contracts/interfaces/IFundV3.sol
+++ b/contracts/interfaces/IFundV3.sol
@@ -113,11 +113,6 @@ interface IFundV3 {
 
     function isFundActive(uint256 timestamp) external view returns (bool);
 
-    function isPrimaryMarketActive(address primaryMarket, uint256 timestamp)
-        external
-        view
-        returns (bool);
-
     function getEquivalentTotalB() external view returns (uint256);
 
     function getEquivalentTotalQ() external view returns (uint256);

--- a/test/fundV3.ts
+++ b/test/fundV3.ts
@@ -204,7 +204,7 @@ describe("FundV3", function () {
 
     // TODO move to rebalance session
     describe("isFundActive()", function () {
-        it("Should revert transfer when inactive", async function () {
+        it("Should transfer Q when inactive", async function () {
             await twapOracle.mock.getTwap.returns(parseEther("1510"));
             await pmCreate(user1, parseBtc("1"), parseEther("500"));
             await advanceOneDayAndSettle();
@@ -212,10 +212,10 @@ describe("FundV3", function () {
             expect(await fund.isFundActive(startDay + POST_REBALANCE_DELAY_TIME - 1)).to.equal(
                 false
             );
-            await expect(shareQ.call(fund, "shareTransfer", addr1, addr2, 0)).to.be.revertedWith(
-                "Transfer is inactive"
-            );
+            await shareQ.call(fund, "shareTransfer", addr1, addr2, 0);
         });
+
+        // TODO: Should revert transfer B/R when inactive
 
         it("Should return the activity window without rebalance", async function () {
             expect(await fund.fundActivityStartTime()).to.equal(startDay - DAY);

--- a/test/fundV3.ts
+++ b/test/fundV3.ts
@@ -215,7 +215,21 @@ describe("FundV3", function () {
             await shareQ.call(fund, "shareTransfer", addr1, addr2, 0);
         });
 
-        // TODO: Should revert transfer B/R when inactive
+        it("Should transfer B/R reverts when inactive", async function () {
+            await twapOracle.mock.getTwap.returns(parseEther("1510"));
+            await pmCreate(user1, parseBtc("1"), parseEther("500"));
+            await advanceOneDayAndSettle();
+
+            expect(await fund.isFundActive(startDay + POST_REBALANCE_DELAY_TIME - 1)).to.equal(
+                false
+            );
+            await expect(shareB.call(fund, "shareTransfer", addr1, addr2, 0)).to.be.revertedWith(
+                "Transfer is inactive"
+            );
+            await expect(shareR.call(fund, "shareTransfer", addr1, addr2, 0)).to.be.revertedWith(
+                "Transfer is inactive"
+            );
+        });
 
         it("Should return the activity window without rebalance", async function () {
             expect(await fund.fundActivityStartTime()).to.equal(startDay - DAY);

--- a/test/fundV3.ts
+++ b/test/fundV3.ts
@@ -248,56 +248,6 @@ describe("FundV3", function () {
         });
     });
 
-    describe("isPrimaryMarketActive()", function () {
-        it("Should return inactive for non-primaryMarket contracts", async function () {
-            expect(await fund.fundActivityStartTime()).to.equal(startDay - DAY);
-            expect(await fund.currentDay()).to.equal(startDay);
-            expect(await fund.isPrimaryMarketActive(addr1, startDay - DAY + HOUR * 12)).to.equal(
-                false
-            );
-        });
-
-        it("Should return the activity window without rebalance", async function () {
-            expect(await fund.fundActivityStartTime()).to.equal(startDay - DAY);
-            expect(await fund.currentDay()).to.equal(startDay);
-            expect(
-                await fund.isPrimaryMarketActive(primaryMarket.address, startDay - DAY + HOUR * 12)
-            ).to.equal(true);
-
-            await twapOracle.mock.getTwap.returns(parseEther("1000"));
-            await advanceOneDayAndSettle();
-
-            expect(await fund.fundActivityStartTime()).to.equal(startDay);
-            expect(await fund.currentDay()).to.equal(startDay + DAY);
-            expect(
-                await fund.isPrimaryMarketActive(primaryMarket.address, startDay + HOUR * 12)
-            ).to.equal(true);
-        });
-
-        it("Should return the activity window with rebalance", async function () {
-            await twapOracle.mock.getTwap.returns(parseEther("1510"));
-            await pmCreate(user1, parseBtc("1"), parseEther("500"));
-            await advanceOneDayAndSettle();
-
-            expect(await fund.fundActivityStartTime()).to.equal(
-                startDay + POST_REBALANCE_DELAY_TIME
-            );
-            expect(await fund.currentDay()).to.equal(startDay + DAY);
-            expect(
-                await fund.isPrimaryMarketActive(
-                    primaryMarket.address,
-                    startDay + POST_REBALANCE_DELAY_TIME - 1
-                )
-            ).to.equal(false);
-            expect(
-                await fund.isPrimaryMarketActive(
-                    primaryMarket.address,
-                    startDay + POST_REBALANCE_DELAY_TIME
-                )
-            ).to.equal(true);
-        });
-    });
-
     describe("FundRoles", function () {
         describe("Primary market and strategy", function () {
             let newPm: MockContract;

--- a/test/primaryMarketV3.ts
+++ b/test/primaryMarketV3.ts
@@ -48,7 +48,6 @@ describe("PrimaryMarketV3", function () {
         await fund.mock.twapOracle.returns(twapOracle.address);
         await fund.mock.tokenUnderlying.returns(btc.address);
         await fund.mock.underlyingDecimalMultiplier.returns(1e10);
-        await fund.mock.isPrimaryMarketActive.returns(true);
         await fund.mock.getTotalUnderlying.returns(TOTAL_UNDERLYING);
         await fund.mock.getEquivalentTotalQ.returns(EQUIVALENT_TOTAL_Q);
         await fund.mock.splitRatio.returns(SPLIT_RATIO);
@@ -96,12 +95,6 @@ describe("PrimaryMarketV3", function () {
     describe("create()", function () {
         const inBtc = parseBtc("1");
         const outQ = inBtc.mul(EQUIVALENT_TOTAL_Q).div(TOTAL_UNDERLYING);
-
-        it("Should not check activeness", async function () {
-            await fund.mock.isPrimaryMarketActive.returns(false);
-            await fund.mock.primaryMarketMint.returns();
-            await primaryMarket.create(addr1, inBtc, 0, 0);
-        });
 
         it("Should transfer underlying from msg.sender", async function () {
             await fund.mock.primaryMarketMint.returns();
@@ -196,13 +189,6 @@ describe("PrimaryMarketV3", function () {
             .div(10000);
         const outBtc = inQ.mul(TOTAL_UNDERLYING).div(EQUIVALENT_TOTAL_Q).sub(feeBtc);
 
-        it("Should not check activeness", async function () {
-            await fund.mock.isPrimaryMarketActive.returns(false);
-            await fund.mock.primaryMarketBurn.returns();
-            await fund.mock.primaryMarketTransferUnderlying.returns();
-            await primaryMarket.redeem(addr2, inQ, 0, 999);
-        });
-
         it("Should burn QUEEN and transfer underlying", async function () {
             const version = 999;
             await expect(() => primaryMarket.redeem(addr2, inQ, 0, version)).to.callMocks(
@@ -266,13 +252,6 @@ describe("PrimaryMarketV3", function () {
         const inQ = parseEther("10");
         const outB = inQ.mul(SPLIT_RATIO).div(parseEther("1"));
 
-        it("Should not check activeness", async function () {
-            await fund.mock.isPrimaryMarketActive.returns(false);
-            await fund.mock.primaryMarketBurn.returns();
-            await fund.mock.primaryMarketMint.returns();
-            await primaryMarket.split(addr2, inQ, 999);
-        });
-
         it("Should burn and mint tranche tokens and add fee debt", async function () {
             const version = 999;
             await expect(() => primaryMarket.split(addr2, inQ, version)).to.callMocks(
@@ -318,14 +297,6 @@ describe("PrimaryMarketV3", function () {
         const feeQ = outQBeforeFee.mul(MERGE_FEE_BPS).div(10000);
         const outQ = outQBeforeFee.sub(feeQ);
         const feeBtc = feeQ.mul(TOTAL_UNDERLYING).div(EQUIVALENT_TOTAL_Q);
-
-        it("Should not check activeness", async function () {
-            await fund.mock.isPrimaryMarketActive.returns(false);
-            await fund.mock.primaryMarketBurn.returns();
-            await fund.mock.primaryMarketMint.returns();
-            await fund.mock.primaryMarketAddDebt.returns();
-            await primaryMarket.merge(addr2, inB, 999);
-        });
 
         it("Should burn and mint tranche tokens and add fee debt", async function () {
             const version = 999;
@@ -380,13 +351,6 @@ describe("PrimaryMarketV3", function () {
             .mul(REDEMPTION_FEE_BPS)
             .div(10000);
         const outBtc = inQ.mul(TOTAL_UNDERLYING).div(EQUIVALENT_TOTAL_Q).sub(feeBtc);
-
-        it("Should not check activeness", async function () {
-            await fund.mock.isPrimaryMarketActive.returns(false);
-            await fund.mock.primaryMarketBurn.returns();
-            await fund.mock.primaryMarketAddDebt.returns();
-            await primaryMarket.queueRedemption(addr2, inQ, 0, 999);
-        });
 
         it("Should burn QUEEN and add debt", async function () {
             const version = 999;

--- a/test/primaryMarketV3.ts
+++ b/test/primaryMarketV3.ts
@@ -97,11 +97,10 @@ describe("PrimaryMarketV3", function () {
         const inBtc = parseBtc("1");
         const outQ = inBtc.mul(EQUIVALENT_TOTAL_Q).div(TOTAL_UNDERLYING);
 
-        it("Should check activeness", async function () {
+        it("Should not check activeness", async function () {
             await fund.mock.isPrimaryMarketActive.returns(false);
-            await expect(primaryMarket.create(addr1, inBtc, 0, 0)).to.be.revertedWith(
-                "Only when active"
-            );
+            await fund.mock.primaryMarketMint.returns();
+            await primaryMarket.create(addr1, inBtc, 0, 0);
         });
 
         it("Should transfer underlying from msg.sender", async function () {
@@ -197,11 +196,11 @@ describe("PrimaryMarketV3", function () {
             .div(10000);
         const outBtc = inQ.mul(TOTAL_UNDERLYING).div(EQUIVALENT_TOTAL_Q).sub(feeBtc);
 
-        it("Should check activeness", async function () {
+        it("Should not check activeness", async function () {
             await fund.mock.isPrimaryMarketActive.returns(false);
-            await expect(primaryMarket.redeem(addr1, inQ, 0, 0)).to.be.revertedWith(
-                "Only when active"
-            );
+            await fund.mock.primaryMarketBurn.returns();
+            await fund.mock.primaryMarketTransferUnderlying.returns();
+            await primaryMarket.redeem(addr2, inQ, 0, 999);
         });
 
         it("Should burn QUEEN and transfer underlying", async function () {
@@ -267,9 +266,11 @@ describe("PrimaryMarketV3", function () {
         const inQ = parseEther("10");
         const outB = inQ.mul(SPLIT_RATIO).div(parseEther("1"));
 
-        it("Should check activeness", async function () {
+        it("Should not check activeness", async function () {
             await fund.mock.isPrimaryMarketActive.returns(false);
-            await expect(primaryMarket.split(addr1, inQ, 0)).to.be.revertedWith("Only when active");
+            await fund.mock.primaryMarketBurn.returns();
+            await fund.mock.primaryMarketMint.returns();
+            await primaryMarket.split(addr2, inQ, 999);
         });
 
         it("Should burn and mint tranche tokens and add fee debt", async function () {
@@ -318,9 +319,12 @@ describe("PrimaryMarketV3", function () {
         const outQ = outQBeforeFee.sub(feeQ);
         const feeBtc = feeQ.mul(TOTAL_UNDERLYING).div(EQUIVALENT_TOTAL_Q);
 
-        it("Should check activeness", async function () {
+        it("Should not check activeness", async function () {
             await fund.mock.isPrimaryMarketActive.returns(false);
-            await expect(primaryMarket.merge(addr1, inB, 0)).to.be.revertedWith("Only when active");
+            await fund.mock.primaryMarketBurn.returns();
+            await fund.mock.primaryMarketMint.returns();
+            await fund.mock.primaryMarketAddDebt.returns();
+            await primaryMarket.merge(addr2, inB, 999);
         });
 
         it("Should burn and mint tranche tokens and add fee debt", async function () {
@@ -377,11 +381,11 @@ describe("PrimaryMarketV3", function () {
             .div(10000);
         const outBtc = inQ.mul(TOTAL_UNDERLYING).div(EQUIVALENT_TOTAL_Q).sub(feeBtc);
 
-        it("Should check activeness", async function () {
+        it("Should not check activeness", async function () {
             await fund.mock.isPrimaryMarketActive.returns(false);
-            await expect(primaryMarket.queueRedemption(addr1, inQ, 0, 0)).to.be.revertedWith(
-                "Only when active"
-            );
+            await fund.mock.primaryMarketBurn.returns();
+            await fund.mock.primaryMarketAddDebt.returns();
+            await primaryMarket.queueRedemption(addr2, inQ, 0, 999);
         });
 
         it("Should burn QUEEN and add debt", async function () {

--- a/test/stableSwap.ts
+++ b/test/stableSwap.ts
@@ -1439,7 +1439,6 @@ describe("Flash Swap", function () {
         await fund.mock.tokenShare.withArgs(TRANCHE_B).returns(tokens[0].address);
         await fund.mock.tokenUnderlying.returns(btc.address);
         await fund.mock.underlyingDecimalMultiplier.returns(1e10);
-        await fund.mock.isPrimaryMarketActive.returns(true);
         await fund.mock.splitRatio.returns(SPLIT_RATIO);
         await fund.mock.getTotalUnderlying.returns(TOTAL_UNDERLYING);
         await fund.mock.getEquivalentTotalQ.returns(EQUIVALENT_TOTAL_Q);


### PR DESCRIPTION
- Removed `onlyActive` and `isPrimaryMarketActive`. It's not required that the fund is active to perform primary market operations.
- Allowed tranche B & R transfer when fund is inactive.