### PR TITLE
Fixed "Warning: Return value of low-level calls not used."

### DIFF
--- a/contracts/fund/FundV3.sol
+++ b/contracts/fund/FundV3.sol
@@ -992,14 +992,11 @@ contract FundV3 is IFundV3, Ownable, ReentrancyGuard, FundRolesV2, CoreUtility {
             // Call `feeCollector.checkpoint()` without errors.
             // This is a intended behavior because `feeCollector` may not have `checkpoint()`.
             (bool success, ) = feeCollector.call(abi.encodeWithSignature("checkpoint()"));
-            // Being hacky to supress the warning "Return value of low-level calls not used."
-            if (success) {
-                IERC20(tokenUnderlying).safeTransfer(feeCollector, amount);
-                emit FeeDebtPaid(amount);
-            } else {
-                IERC20(tokenUnderlying).safeTransfer(feeCollector, amount);
-                emit FeeDebtPaid(amount);
+            if (!success) {
+                // ignore
             }
+            IERC20(tokenUnderlying).safeTransfer(feeCollector, amount);
+            emit FeeDebtPaid(amount);
         }
     }
 

--- a/contracts/fund/FundV3.sol
+++ b/contracts/fund/FundV3.sol
@@ -991,9 +991,15 @@ contract FundV3 is IFundV3, Ownable, ReentrancyGuard, FundRolesV2, CoreUtility {
             _totalDebt = total - amount;
             // Call `feeCollector.checkpoint()` without errors.
             // This is a intended behavior because `feeCollector` may not have `checkpoint()`.
-            feeCollector.call(abi.encodeWithSignature("checkpoint()"));
-            IERC20(tokenUnderlying).safeTransfer(feeCollector, amount);
-            emit FeeDebtPaid(amount);
+            (bool success, ) = feeCollector.call(abi.encodeWithSignature("checkpoint()"));
+            // Being hacky to supress the warning "Return value of low-level calls not used."
+            if (success) {
+                IERC20(tokenUnderlying).safeTransfer(feeCollector, amount);
+                emit FeeDebtPaid(amount);
+            } else {
+                IERC20(tokenUnderlying).safeTransfer(feeCollector, amount);
+                emit FeeDebtPaid(amount);
+            }
         }
     }
 


### PR DESCRIPTION
If we don't read the returned value of `feeCollector.call` at all, we will get "Warning: Return value of low-level calls not used."

If we read the returned `success`, we will get "Warning: Unused local variable." 

Therefore, I used a hacky way to circumvent the issue.