### PR TITLE
Cancel bid orders in BatchUpgradeTool

### DIFF
--- a/contracts/tranchessV1/exchange/ExchangeV3.sol
+++ b/contracts/tranchessV1/exchange/ExchangeV3.sol
@@ -438,10 +438,7 @@ contract ExchangeV3 is ExchangeRoles, StakingV3, ProxyUtility {
         OrderQueue storage orderQueue = bids[version][tranche][pdLevel];
         Order storage order = orderQueue.list[index];
         address maker = order.maker;
-        // Bid orders can be canceled by anyone after the upgrade
-        if (block.timestamp < upgradeTimestamp) {
-            require(maker == msg.sender, "Maker address mismatched");
-        }
+        require(maker == msg.sender, "Maker address mismatched");
 
         uint256 fillable = order.fillable;
         emit BidOrderCanceled(maker, tranche, pdLevel, order.amount, version, index, fillable);

--- a/contracts/tranchessV1/exchange/ExchangeV3.sol
+++ b/contracts/tranchessV1/exchange/ExchangeV3.sol
@@ -434,13 +434,13 @@ contract ExchangeV3 is ExchangeRoles, StakingV3, ProxyUtility {
         uint256 tranche,
         uint256 pdLevel,
         uint256 index
-    ) external whenNotPaused {
+    ) external whenNotPaused returns (uint256 fillable) {
         OrderQueue storage orderQueue = bids[version][tranche][pdLevel];
         Order storage order = orderQueue.list[index];
         address maker = order.maker;
         require(maker == msg.sender, "Maker address mismatched");
 
-        uint256 fillable = order.fillable;
+        fillable = order.fillable;
         emit BidOrderCanceled(maker, tranche, pdLevel, order.amount, version, index, fillable);
         orderQueue.cancel(index);
 

--- a/contracts/tranchessV1/upgrade/BatchUpgradeTool.sol
+++ b/contracts/tranchessV1/upgrade/BatchUpgradeTool.sol
@@ -10,8 +10,21 @@ import "./UpgradeTool.sol";
 contract BatchUpgradeTool {
     using SafeMath for uint256;
 
-    /// @dev Each value of `encodedEpochs` encodes an exchange index (32 bits),
-    ///      a maker/taker flag (32 bits, 0 for maker, 1 for taker) and the epoch timestamp.
+    /// @dev `encodedData` consists of two types of data:
+    ///      - unsettled epochs
+    ///      - bid orders
+    //       Unsettled epochs are encoded as follows:
+    //       Bit  255       | 0 (constant)
+    //       Bit [224, 228) | exchangeIndex
+    //       Bit 192        | 0 (maker), 1(taker)
+    //       Bit [0, 64)    | epoch
+    //       Bid orders are encoded as follows:
+    //       Bit  255       | 1 (constant)
+    //       Bit [224, 228) | exchangeIndex
+    //       Bit [76, 80)   | version
+    //       Bit [72, 76)   | tranche
+    //       Bit [64, 72)   | pdLevel
+    //       Bit [0, 64)    | index
     /// @return tokenAmounts An array of (upgradeTools.length * 3) values, containing the amount
     ///         of three tokens upgraded for each Fund
     /// @return underlyingAmounts An array of (oldPrimaryMarkets.length + oldWrappedPrimaryMarkets.length)
@@ -46,21 +59,6 @@ contract BatchUpgradeTool {
                 .claimAndUnwrap(account);
         }
 
-        /// @dev `encodedData` contains two types of data:
-        ///      - unsettled epochs
-        ///      - bid orders
-        //       Unsettled epochs are encoded as follows:
-        //       Bit  255       | 0 (constant)
-        //       Bit [224, 228) | exchangeIndex
-        //       Bit 192        | 0 (maker), 1(taker)
-        //       Bit [0, 64)    | epoch
-        //       Bid orders are encoded as follows:
-        //       Bit  255       | 1 (constant)
-        //       Bit [224, 228) | exchangeIndex
-        //       Bit [76, 80)   | version
-        //       Bit [72, 76)   | tranche
-        //       Bit [64, 72)   | pdLevel
-        //       Bit [0, 64)    | index
         for (uint256 i = 0; i < encodedData.length; i++) {
             uint256 encodedDatum = encodedData[i];
             uint256 exchangeIndex = (encodedDatum >> 224) & 0xF;

--- a/test/tranchessV1/exchangeUpgradeV2ToV3.ts
+++ b/test/tranchessV1/exchangeUpgradeV2ToV3.ts
@@ -523,25 +523,6 @@ describe("Exchange upgrade V2 to V3", function () {
             );
         });
 
-        it("Should allow bid orders to be canceled by others", async function () {
-            await upgradeToV3();
-            await advanceBlockAtTime(upgradeEpoch);
-            // Canceled by self
-            await expect(() => exchange.cancelBid(0, TRANCHE_A, 41, 1)).to.changeTokenBalances(
-                usdc,
-                [user1, exchange],
-                [BID_1_PD_0.div(USDC_TO_ETHER), BID_1_PD_0.div(USDC_TO_ETHER).mul(-1)]
-            );
-            // Canceled by other
-            await expect(() =>
-                exchange.connect(user2).cancelBid(0, TRANCHE_B, 41, 1)
-            ).to.changeTokenBalances(
-                usdc,
-                [user1, exchange],
-                [BID_1_PD_0.div(USDC_TO_ETHER), BID_1_PD_0.div(USDC_TO_ETHER).mul(-1)]
-            );
-        });
-
         it("Should reject deposits", async function () {
             await upgradeToV3();
             await advanceBlockAtTime(upgradeEpoch);


### PR DESCRIPTION
1. Reverts the change that allows other users to cancel order in `ExchangeV3`. Now it behaves as `ExchangeV2`.
2. Performs bid order cancellation in `BatchUpgradeTool`. Due to stack size limit, we encode the epoch of unsettled trades and bid orders to cancel in one `uint256`, distinguished by the most significant bit.