### PR TITLE
Update bribe params

### DIFF
--- a/contracts/governance/Briber.sol
+++ b/contracts/governance/Briber.sol
@@ -35,8 +35,8 @@ contract Briber is Ownable {
         token = token_;
     }
 
-    function bribe(uint256 proposalIndex, uint256 choiceIndex) external onlyOwner {
-        bytes32 proposal = keccak256(abi.encodePacked(proposalIndex, choiceIndex));
+    function bribe(address gauge) external onlyOwner {
+        bytes32 proposal = keccak256(abi.encodePacked(gauge));
         rewardClaimer.claimRewards();
         uint256 bribeAmount = IERC20(token).balanceOf(address(this));
         IERC20(token).safeApprove(bribeMarket.BRIBE_VAULT(), bribeAmount);

--- a/contracts/governance/Briber.sol
+++ b/contracts/governance/Briber.sol
@@ -37,6 +37,14 @@ contract Briber is Ownable {
 
     function bribe(address gauge) external onlyOwner {
         bytes32 proposal = keccak256(abi.encodePacked(gauge));
+        _bribe(proposal);
+    }
+
+    function bribe(bytes32 proposal) external onlyOwner {
+        _bribe(proposal);
+    }
+
+    function _bribe(bytes32 proposal) private {
         rewardClaimer.claimRewards();
         uint256 bribeAmount = IERC20(token).balanceOf(address(this));
         IERC20(token).safeApprove(bribeMarket.BRIBE_VAULT(), bribeAmount);


### PR DESCRIPTION
Turns out starting from HiddenHand V2, we should use the gauge address (from balancer) instead of "choice index" and "proposal index". According to https://github.com/aurafinance/aura-contracts/blob/main/tasks/snapshot/gauge_choices.json, the gauge address is `0x06d27c0FE5AbF6020bf56E47c72Ca002dD5d9f54`